### PR TITLE
Supports pagination for search results

### DIFF
--- a/src/actionCreators/search.js
+++ b/src/actionCreators/search.js
@@ -29,6 +29,8 @@ export const fetchSinopiaSearchResults =
           )
         )
         dispatch(addApiSearchHistory(sinopiaSearchUri, query, keycloak))
+        // Use extracted options from response if available, otherwise use passed options
+        const finalOptions = response.options || options
         dispatch(
           setSearchResults(
             "resource",
@@ -37,8 +39,9 @@ export const fetchSinopiaSearchResults =
             response.totalHits,
             facetResponse || {},
             query,
-            options,
-            response.error
+            finalOptions,
+            response.error,
+            response.links
           )
         )
         if (response.results) {

--- a/src/actions/search.js
+++ b/src/actions/search.js
@@ -11,7 +11,8 @@ export const setSearchResults = (
   facetResults,
   query,
   options,
-  error
+  error,
+  links
 ) => ({
   type: "SET_SEARCH_RESULTS",
   payload: {
@@ -23,6 +24,7 @@ export const setSearchResults = (
     query,
     options,
     error,
+    links,
   },
 })
 

--- a/src/components/search/Search.jsx
+++ b/src/components/search/Search.jsx
@@ -13,6 +13,7 @@ import {
   selectSearchUri,
   selectSearchOptions,
   selectSearchTotalResults,
+  selectSearchLinks,
 } from "selectors/search"
 import { sinopiaSearchUri } from "utilities/authorityConfig"
 import useSearch from "hooks/useSearch"
@@ -38,9 +39,10 @@ const Search = (props) => {
   const totalResults = useSelector((state) =>
     selectSearchTotalResults(state, "resource")
   )
+  const links = useSelector((state) => selectSearchLinks(state, "resource"))
 
-  const changeSearchPage = (startOfRange) => {
-    fetchSearchResults(queryString, uri, searchOptions, startOfRange, keycloak)
+  const changeSearchPage = (linkUrl) => {
+    fetchSearchResults(linkUrl, uri, searchOptions, null, keycloak)
   }
 
   return (
@@ -59,6 +61,7 @@ const Search = (props) => {
           resultsPerPage={searchOptions.resultsPerPage}
           startOfRange={searchOptions.startOfRange}
           totalResults={totalResults}
+          links={links}
           changePage={changeSearchPage}
         />
         <SearchResultsMessage />

--- a/src/components/search/SearchResultsPaging.jsx
+++ b/src/components/search/SearchResultsPaging.jsx
@@ -8,6 +8,36 @@ const SearchResultsPaging = (props) => {
 
   const changePage = (event, page) => {
     event.preventDefault()
+    const lastPage = Math.ceil(props.totalResults / props.resultsPerPage)
+
+    // If we have links and it's a next/previous action, use the link URL
+    if (props.links) {
+      if (page === currentPage + 1) {
+        if (props.links.next) {
+          props.changePage(props.links.next)
+        }
+        return
+      }
+      if (page === currentPage - 1) {
+        if (props.links.prev) {
+          props.changePage(props.links.prev)
+        }
+        return
+      }
+      if (page === 1) {
+        if (props.links.first) {
+          props.changePage(props.links.first)
+        }
+        return
+      }
+      if (page === lastPage) {
+        if (props.links.last) {
+          props.changePage(props.links.last)
+        }
+        return
+      }
+    }
+    // Fallback to offset-based pagination for specific page numbers
     props.changePage((page - 1) * props.resultsPerPage)
   }
 
@@ -25,7 +55,23 @@ const SearchResultsPaging = (props) => {
   const pageButton = (key, label, page, active) => {
     const classes = ["page-item"]
     if (active) classes.push("active")
-    if (page < 1 || page > lastPage) classes.push("disabled")
+
+    // Check if button should be disabled
+    let isDisabled = page < 1 || page > lastPage
+
+    // When using links-based pagination, also check link availability
+    if (props.links && !isDisabled) {
+      if (key === "next" && !props.links.next) {
+        isDisabled = true
+      } else if (key === "previous" && !props.links.prev) {
+        isDisabled = true
+      } else if (key === "first" && !props.links.first) {
+        isDisabled = true
+      }
+    }
+
+    if (isDisabled) classes.push("disabled")
+
     return (
       <li key={key} className={classes.join(" ")}>
         <button
@@ -88,6 +134,7 @@ SearchResultsPaging.propTypes = {
   totalResults: PropTypes.number.isRequired,
   resultsPerPage: PropTypes.number.isRequired,
   startOfRange: PropTypes.number.isRequired,
+  links: PropTypes.object,
 }
 
 export default SearchResultsPaging

--- a/src/reducers/search.js
+++ b/src/reducers/search.js
@@ -26,6 +26,7 @@ export const setSearchResults = (state, action) => ({
       typeFilter: action.payload.options?.typeFilter,
       groupFilter: action.payload.options?.groupFilter,
     },
+    links: action.payload.links,
     error: action.payload.error,
   },
 })

--- a/src/selectors/search.js
+++ b/src/selectors/search.js
@@ -24,4 +24,7 @@ export const selectSearchOptions = (state, searchType) =>
 export const selectSearchResults = (state, searchType) =>
   state.search[searchType]?.results
 
+export const selectSearchLinks = (state, searchType) =>
+  state.search[searchType]?.links
+
 export const selectHeaderSearch = (state) => state.editor.currentHeaderSearch


### PR DESCRIPTION
## Why was this change made?
Pagination needs to be available to display search results beyond a single page.
<img width="1735" height="287" alt="Screenshot 2025-12-03 at 12 04 51 PM" src="https://github.com/user-attachments/assets/9e357c8e-621a-4645-8152-4580a9035790" />


## How was this change tested?
In browser


## Which documentation and/or configurations were updated?
n.a


