### PR TITLE
Adds Variant Title Lookup

### DIFF
--- a/static/authorityConfig.json
+++ b/static/authorityConfig.json
@@ -1767,6 +1767,11 @@
     "component": "list"
   },
   {
+    "label": "variant title type",
+    "uri": "https://id.loc.gov/vocabulary/vartitletype",
+    "component": "list"
+  },
+  {
     "label": "propertyAttribute",
     "uri": "file:/propertyAttribute.json",
     "component": "list"


### PR DESCRIPTION
## Why was this change made?
Support for Variant title (mirror Sinopia's PR [4081](https://github.com/LD4P/sinopia_editor/pull/4081)).


## How was this change tested?
In browser


## Which documentation and/or configurations were updated?
n/a


