### PR TITLE
Adds LOC Medium of Component qualifier

### DIFF
--- a/static/authorityConfig.json
+++ b/static/authorityConfig.json
@@ -1672,6 +1672,11 @@
     "component": "list"
   },
   {
+    "label": "medium component qualifier",
+    "uri": "https://id.loc.gov/vocabulary/medcompqual",
+    "component": "list"
+  },
+  {
     "label": "note type",
     "uri": "https://id.loc.gov/vocabulary/mnotetype",
     "component": "list"


### PR DESCRIPTION
## Why was this change made?
Supports https://github.com/LD4P/sinopia_editor/issues/4021, mirrors this Sinopia PR https://github.com/LD4P/sinopia_editor/pull/4091


## How was this change tested?
Locally


## Which documentation and/or configurations were updated?

`static/authorityConfig.json`

