### PR TITLE
Running Blue Core Sinopia for local Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,7 @@ Technical documentation specific to the Sinopia Linked Data Editor may also be f
 * A development cognito account: Go to https://development.sinopia.io/ and click "Request Account". This account can be used to authenticate when running locally as described below.
 
 #### Node version
->= 14 is recommended and <= 16.10 is required.
-
-Newer versions cause Jest memory leaks. See:
-* https://github.com/facebook/jest/issues/7874
-* https://github.com/facebook/jest/issues/11956
+>= 24.4.0
 
 You can use the ["nvm"](https://github.com/nvm-sh/nvm) or ["n"](https://www.npmjs.com/package/n) node package management to manage multiple version of node.
 
@@ -30,32 +26,41 @@ You can use the ["nvm"](https://github.com/nvm-sh/nvm) or ["n"](https://www.npmj
 6.  Run `npm run build`. This will copy some files to `dist/` that are necessary to run locally.
 
 ```
-COGNITO_TEST_USER_NAME='sinopia-devs+client-tester@lists.stanford.edu' # a test user we have on dev and stage
-COGNITO_TEST_USER_PASS='<get this from shared_configs or another developer>' # not committing the real value to a public repo
-COGNITO_ADMIN_PASSWORD='<get this from shared_configs or another developer>'
 DOCKER_AWS_ACCESS_KEY_ID='<get this from shared_configs or another developer>'
 DOCKER_AWS_SECRET_ACCESS_KEY='<get this from shared_configs or another developer>'
 ```
 
 ## Running the application
-To start all of the supporting services (ElasticSearch, API, etc.):
-`docker-compose up -d`
+Use `compose-dev.yaml` in the [Blue Core stack](https://github.com/blue-core-lod/bluecore-stack) repository 
+with latest published Sinopia image. From that repositories root directory, run:
 
-Note that this will bring up the sinopia-editor app on port 8000, but it will NOT be in a mode where
-you can make code changes and see them live.  To do this, start the Express web server (via `npm start`) and run the
-application at [http://localhost:8888](http://localhost:8888):
+`docker compose -f compose-dev.yaml up`
 
-`npm run dev-start`
+Note that this will bring up the sinopia-editor app at [http://localhost/sinopia, but it will NOT be in a mode where
+you can make code changes and see them live.  
+
+### Running the application in development mod
+Start the Express web server (via `npm run dev-start`) with the following variables:
+
+- **SINOPIA_URI**: http://localhost:8888 
+- **SINOPIA_API_BASE_URL**: http://localhost/api 
+- **SEARCH_HOST**: http://localhost/api/ 
+- **KEYCLOAK_URL**: http://localhost:8888/keycloak
+
+Full command:
+
+`SINOPIA_URI=http://localhost:8888 SINOPIA_API_BASE_URL=http://localhost/api SEARCH_HOST=http://localhost/api/ KEYCLOAK_URL=http://localhost:8888/keycloak search npm run dev-start` 
+
+Sinopia in development mode will be available at [http://localhost:8888](http://localhost:8888).
 
 This will run the app in development mode and code changes will immediately be loaded without having to restart the server.
-Note that sinopia editor being run by docker on port 8000 will still be viewable but will not reflect any code changes you make
-immediately, so be careful which port you are accessing the app at to avoid confusion.
+Note that sinopia editor being run by docker on port 80 will still be viewable but will not reflect any code changes you make immediately, so be careful which port you are accessing the app at to avoid confusion.
 
 Specify the environment variable `USE_FIXTURES=true` as shown below if you would like to use fixture resources and resource templates.
 The fixtures are listed in `__tests__/testUtilities/fixtureLoaderHelper.js`. Fixture resource templates will be listed on the
 templates list page and fixture resources can be searched on by entering the resource's URI in the Sinopia search box.
 
-`USE_FIXTURES=true npm run dev-start`
+`SINOPIA_URI=http://localhost:8888 SINOPIA_API_BASE_URL=http://localhost/api SEARCH_HOST=http://localhost/api/ KEYCLOAK_URL=http://localhost:8888/keycloak search npm run dev-start USE_FIXTURES=true npm run dev-start`
 
 ## Developers
 
@@ -116,55 +121,9 @@ section from `package.json`.
 
 While there are a large number of possible causes for this error (see Google), it is most likely a timeout that needs to be increased.
 
-#### End-to-end tests
-
-End-to-end tests are written with [Cypress](https://www.cypress.io/).
-
-Add these to your local `cypress.env.json` file:
-```
-{
-  "COGNITO_TEST_USER_NAME": "sinopia-devs_client-tester",
-  "COGNITO_TEST_USER_PASS": "<get this from shared_configs or another developer>"
-}
-```
-
-The end-to-end tests run against a complete environment running in docker, so it must be running as described above.
-
-To open Cypress interactively (for test development), execute `npm run cypress-open` and click on the test to run.
-
-To run test non-interactively, execute `npm run cypress-run`.
-
-#### Cross Platform Testing
-
-We use open source [![Browserstack](https://github.com/LD4P/sinopia_editor/wiki/images/Browserstack-logo.png)](https://www.browserstack.com) accounts for cross-platform/browser testing. See the [Sinopia Editor wiki](https://github.com/LD4P/sinopia_editor/wiki/Cross-Platform-Browser-Testing) for more details about how to get an account.
-
-#### Testing Honeybadger
-To trigger a test exception, doubleclick "The underdrawing for the new world of linked data in libraries" on the home page.
-
-### Monitoring ElasticSearch
-DejaVu is available for monitoring local ElasticSearch.
-
-To use DejaVu:
-1. Uncomment the appropriate section in `docker-compose.yml`. (Do not commit this change.)
-2. `docker-compose up -d`
-3. Browse to http://localhost:1358.
-4. When prompted, enter `http://localhost:9200` as the ElasticSearch URL and `*` as the index name.
-
-### Monitoring Mongo
-Mongo-Express is available for monitoring local Mongo.
-
-To use Mongo-Express:
-1. Uncomment the appropriate section in `docker-compose.yml`. (Do not commit this change.)
-2. `docker-compose up -d`
-3. Browse to http://localhost:8082.
-
-### Release management (including weekly dependency update) instructions
-
-See the [release process](/release_process.md) checklist.
-
 #### Changes to environment variables
 
-If you add environment variables to which the Editor needs to pay attention (e.g. for configuring connections to Cognito or other external services on a per-instance basis), you'll need to make sure they're added to lists in three places besides e.g. the `Config.js` function that uses the environment variable.
+If you add environment variables to which the Editor needs to pay attention (e.g. for configuring connections to external services on a per-instance basis), you'll need to make sure they're added to lists in three places besides e.g. the `Config.js` function that uses the environment variable.
 * the list given to `new webpack.EnvironmentPlugin()` in the `plugins` section of `webpack.config.js`
   * e.g. https://github.com/LD4P/sinopia_editor/commit/aadd9d6170b08ff9261392d5b2ec2c6f56470e20#diff-11e9f7f953edc64ba14b0cc350ae7b9dR58
 * the build-time arguments section of `Dockerfile`
@@ -367,22 +326,6 @@ The following are only in the resource subject (that is, the base subject).
 -> Added by selector, not stored in state.
 
 Note: A value will have literal / lang or uri / label or valueSubjectKey.
-
-## Contributors
-
-* [Jeremy Nelson](https://github.com/jermnelson)
-* [Kevin Ford](https://github.com/kefo)
-* [Kirk Hess](https://github.com/kirkhess)
-
-[Index Data](http://indexdata.com/):
-* [Charles Ledvina](https://github.com/cledvina)
-* [Wayne Schneider](https://github.com/wafschneider)
-
-## Maintainer
-
-* **LD4P2 Sinopia Project Team**
-  * [GitHub](https://github.com/ld4p/)
-
 
 ## License
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -108,6 +108,10 @@ module.exports = {
     port: 8888,
     proxy: {
       "/api/search": "http://localhost:8000",
+      "/keycloak": {
+        target: "http://localhost",
+        changeOrigin: true,
+      },
     },
   },
 }


### PR DESCRIPTION
## Why was this change made?
Directions for running Blue Core Sinopia in development mode for local development along with webpack change to proxy keycloak correctly.


## How was this change tested?
Unit and Feature tests


## Which documentation and/or configurations were updated?
README.md


