### PR TITLE
React can't render a plain object as a child, returns error #31.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Start the Express web server (via `npm run dev-start`) with the following variab
 
 Full command:
 
-`SINOPIA_URI=http://localhost:8888 SINOPIA_API_BASE_URL=http://localhost/api SEARCH_HOST=http://localhost/api/ KEYCLOAK_URL=http://localhost:8888/keycloak npm run dev-start` 
+`SINOPIA_URI=http://localhost:8888 SINOPIA_API_BASE_URL=http://localhost/api SEARCH_HOST=http://localhost/api/search KEYCLOAK_URL=http://localhost:8888/keycloak npm run dev-start` 
 
 Sinopia in development mode will be available at [http://localhost:8888](http://localhost:8888).
 

--- a/__tests__/sinopiaSearch.test.js
+++ b/__tests__/sinopiaSearch.test.js
@@ -198,6 +198,52 @@ describe("getSearchResults", () => {
     expect(typeof results.results[0].label).toBe("string")
     expect(results.results[0].label).toBe("Hineh yamim baʼim")
   })
+
+  it("extracts a string label when title is an array of typed title objects and mainTitle contains language-tagged objects", async () => {
+    const jsonLdResult = {
+      total: 1,
+      results: [
+        {
+          uri: "https://dev.bcld.info/works/9d545a93-2baa-423a-8f62-a0f510ece78c",
+          data: {
+            "@type": ["Work", "Text", "Monograph"],
+            title: [
+              {
+                "@type": "VariantTitle",
+                mainTitle: [
+                  "Hŭk esŏ ch'ajŭn yŏngwŏn han sam",
+                  { "@value": "흙 에서 찾은 영원 한 삶", "@language": "ko-kore" },
+                ],
+                variantType: "portion",
+              },
+              {
+                "@type": "Title",
+                mainTitle: [
+                  "Palgul sokpo! hŭk esŏ ch'ajŭn yŏngwŏn han sam",
+                  { "@value": "발굴 속보! 흙 에서 찾은 영원 한 삶", "@language": "ko-kore" },
+                ],
+              },
+            ],
+          },
+          created_at: "2025-07-10T03:28:19.651996",
+          updated_at: "2025-07-10T03:28:19.651996",
+        },
+      ],
+      links: null,
+    }
+
+    global.fetch = jest
+      .fn()
+      .mockImplementation(() =>
+        Promise.resolve({ json: () => jsonLdResult })
+      )
+
+    const results = await getSearchResults("Palgul sokpo")
+    expect(typeof results.results[0].label).toBe("string")
+    expect(results.results[0].label).toBe(
+      "Palgul sokpo! hŭk esŏ ch'ajŭn yŏngwŏn han sam"
+    )
+  })
 })
 
 describe("getSearchResultsWithFacets", () => {

--- a/__tests__/sinopiaSearch.test.js
+++ b/__tests__/sinopiaSearch.test.js
@@ -164,6 +164,40 @@ describe("getSearchResults", () => {
     expect(typeof results.results[0].label).toBe("string")
     expect(results.results[0].label).toBe("Encyclopedia of radical helping")
   })
+
+  it("extracts a string label from mainTitle array containing language-tagged objects", async () => {
+    const jsonLdResult = {
+      total: 1,
+      results: [
+        {
+          uri: "https://dev.bcld.info/works/a85c7d32-7138-4ebb-bdd2-8748b2489820",
+          data: {
+            "@type": ["Monograph", "Work", "Text"],
+            title: {
+              "@type": "Title",
+              mainTitle: [
+                "Hineh yamim baʼim",
+                { "@value": "הנה ימים באים", "@language": "he-hebr" },
+              ],
+            },
+          },
+          created_at: "2025-02-08T01:48:48.515037",
+          updated_at: "2025-02-08T01:48:48.515037",
+        },
+      ],
+      links: null,
+    }
+
+    global.fetch = jest
+      .fn()
+      .mockImplementation(() =>
+        Promise.resolve({ json: () => jsonLdResult })
+      )
+
+    const results = await getSearchResults("Hineh yamim")
+    expect(typeof results.results[0].label).toBe("string")
+    expect(results.results[0].label).toBe("Hineh yamim baʼim")
+  })
 })
 
 describe("getSearchResultsWithFacets", () => {

--- a/__tests__/sinopiaSearch.test.js
+++ b/__tests__/sinopiaSearch.test.js
@@ -133,6 +133,37 @@ describe("getSearchResults", () => {
       options: { noFacetResults: true },
     })
   })
+
+  it("extracts a string label from JSON-LD mainTitle object", async () => {
+    const jsonLdResult = {
+      total: 1,
+      results: [
+        {
+          uri: "https://dev.bcld.info/works/89b8c5b2-9b88-477b-bf5c-a9be977dd1d3",
+          data: {
+            "@type": ["Text", "Monograph", "Work"],
+            title: {
+              "@type": "Title",
+              mainTitle: { "@value": "Encyclopedia of radical helping", "@language": "en" },
+            },
+          },
+          created_at: "2025-11-18T21:53:24.747972",
+          updated_at: "2025-11-18T21:53:24.747972",
+        },
+      ],
+      links: null,
+    }
+
+    global.fetch = jest
+      .fn()
+      .mockImplementation(() =>
+        Promise.resolve({ json: () => jsonLdResult })
+      )
+
+    const results = await getSearchResults("an encyclopedia of radical helping")
+    expect(typeof results.results[0].label).toBe("string")
+    expect(results.results[0].label).toBe("Encyclopedia of radical helping")
+  })
 })
 
 describe("getSearchResultsWithFacets", () => {

--- a/src/sinopiaSearch.js
+++ b/src/sinopiaSearch.js
@@ -181,7 +181,7 @@ const hitsToResult = (payload) => {
       titleObj = titleObj.find((t) => t["@type"] === "Title") || titleObj[0]
     }
     const mainTitle = titleObj?.mainTitle
-    const label = mainTitle
+    const label = mainTitle?.["@value"] ?? mainTitle
 
     results.push({
       uri: hit.uri,

--- a/src/sinopiaSearch.js
+++ b/src/sinopiaSearch.js
@@ -181,7 +181,14 @@ const hitsToResult = (payload) => {
       titleObj = titleObj.find((t) => t["@type"] === "Title") || titleObj[0]
     }
     const mainTitle = titleObj?.mainTitle
-    const label = mainTitle?.["@value"] ?? mainTitle
+    let label
+    if (Array.isArray(mainTitle)) {
+      const first =
+        mainTitle.find((m) => typeof m === "string") ?? mainTitle[0]
+      label = first?.["@value"] ?? first
+    } else {
+      label = mainTitle?.["@value"] ?? mainTitle
+    }
 
     results.push({
       uri: hit.uri,


### PR DESCRIPTION
## Why was this change made?
Fixes #95 

Amended to include both error reports which were failing for slightly different reasons.

## How was this change tested?
By searching SInopia for the error condition and capturing the response object, then writing a test that failed using the same response object, then correcting the code that expected the object to be a string.


## Which documentation and/or configurations were updated?
None.


