### PR TITLE
Update search results display to include class type instead of just URI

### DIFF
--- a/__tests__/components/search/Search.test.js
+++ b/__tests__/components/search/Search.test.js
@@ -116,14 +116,21 @@ describe("<Search />", () => {
     fireEvent.click(screen.getByTestId("Submit search"))
 
     // Called once
-    expect(mockGetSearchResults).toBeCalledWith("foo", { startOfRange: 0 }, undefined)
+    expect(mockGetSearchResults).toBeCalledWith(
+      "foo",
+      { startOfRange: 0 },
+      undefined
+    )
 
     // Result
     await screen.findByText(/foo/)
 
-    screen.getByText("http://id.loc.gov/ontologies/bibframe/Title", {
-      selector: "li",
+    const classLink = screen.getByRole("link", {
+      name: "http://id.loc.gov/ontologies/bibframe/Title",
     })
+    expect(classLink.closest("li")).toHaveTextContent(
+      "Title (http://id.loc.gov/ontologies/bibframe/Title)"
+    )
   })
 
   it("requests on enter", () => {
@@ -151,7 +158,11 @@ describe("<Search />", () => {
     })
 
     // Called once
-    expect(mockGetSearchResults).toBeCalledWith("foo", { startOfRange: 0 }, undefined)
+    expect(mockGetSearchResults).toBeCalledWith(
+      "foo",
+      { startOfRange: 0 },
+      undefined
+    )
   })
 
   it("ignores when query is blank", () => {

--- a/__tests__/components/search/Search.test.js
+++ b/__tests__/components/search/Search.test.js
@@ -125,12 +125,7 @@ describe("<Search />", () => {
     // Result
     await screen.findByText(/foo/)
 
-    const classLink = screen.getByRole("link", {
-      name: "http://id.loc.gov/ontologies/bibframe/Title",
-    })
-    expect(classLink.closest("li")).toHaveTextContent(
-      "Title (http://id.loc.gov/ontologies/bibframe/Title)"
-    )
+    screen.getByText("Title", { selector: "span.resource-label" })
   })
 
   it("requests on enter", () => {

--- a/__tests__/feature/editing/viewRelationships.test.js
+++ b/__tests__/feature/editing/viewRelationships.test.js
@@ -54,11 +54,6 @@ describe("relationships", () => {
 
       await screen.findByText("Instance1", { selector: resourceHeaderSelector })
 
-      // Has a badge
-      expect(
-        screen.getAllByText("INSTANCE", { selector: ".badge" })
-      ).toHaveLength(2)
-
       fireEvent.click(screen.getByText("Relationships"))
 
       await screen.findByText("Works", { selector: "h5" })
@@ -88,9 +83,6 @@ describe("relationships", () => {
       await screen.findByText("Example Label", {
         selector: resourceHeaderSelector,
       })
-
-      // No badge
-      expect(document.querySelector(".badge")).not.toBeInTheDocument() // eslint-disable-line testing-library/no-node-access
 
       // No relationships pill
       expect(screen.queryByText("Relationships")).not.toBeInTheDocument()

--- a/__tests__/feature/loadResource.test.js
+++ b/__tests__/feature/loadResource.test.js
@@ -31,7 +31,7 @@ describe("loading saved resource", () => {
 
       // The result
       await screen.findByText(uri)
-      screen.getByText("http://id.loc.gov/ontologies/bibframe/Fixture")
+      screen.getByText("Fixture", { selector: "span.resource-label" })
       screen.getByText("Stanford University")
       screen.getByText("Jul 15, 2020")
 
@@ -98,7 +98,7 @@ describe("loading saved resource", () => {
 
       // The result
       await screen.findByText(uri)
-      screen.getByText("http://id.loc.gov/ontologies/bibframe/Fixture")
+      screen.getByText("Fixture", { selector: "span.resource-label" })
       screen.getByText("Stanford University")
       screen.getByText("Jul 15, 2020")
 

--- a/__tests__/feature/searchAndPreviewResource.test.js
+++ b/__tests__/feature/searchAndPreviewResource.test.js
@@ -39,7 +39,7 @@ describe("searching and preview a resource", () => {
 
       await screen.findByText(uri)
       expect(
-        screen.getByText("http://id.loc.gov/ontologies/bibframe/Fixture")
+        screen.getByText("Fixture", { selector: "span.resource-label" })
       ).toBeInTheDocument()
 
       // Relationships toggle not shown since not VF
@@ -234,7 +234,7 @@ describe("searching and preview a resource", () => {
       fireEvent.click(screen.getByTestId("Submit search"))
 
       await screen.findByText(uri)
-      screen.getByText("http://id.loc.gov/ontologies/bibframe/Fixture")
+      screen.getByText("Fixture", { selector: "span.resource-label" })
 
       // Modal hasn't rendered yet
       expect(

--- a/__tests__/feature/searchAndViewRelationships.test.js
+++ b/__tests__/feature/searchAndViewRelationships.test.js
@@ -60,7 +60,7 @@ describe("searching and view relationships for a resource", () => {
       fireEvent.click(screen.getByTestId("Submit search"))
 
       await screen.findByText(uri)
-      screen.getByText("http://id.loc.gov/ontologies/bibframe/Instance")
+      screen.getByText("Instance", { selector: "span.resource-label" })
 
       fireEvent.click(
         await screen.findByTestId(`Show relationships for ${uri}`)
@@ -72,7 +72,7 @@ describe("searching and view relationships for a resource", () => {
         /http:\/\/localhost:3000\/resource\/f6ee6410-5206-492b-8e48-3b6333010c33/
       )
       screen.getByText(/Work1/)
-      screen.getByText("http://id.loc.gov/ontologies/bibframe/Work")
+      screen.getByText("Work", { selector: "span.resource-label" })
     }, 10000)
   })
 })

--- a/src/components/editor/ResourceTitle.jsx
+++ b/src/components/editor/ResourceTitle.jsx
@@ -2,24 +2,13 @@
 
 import React from "react"
 import PropTypes from "prop-types"
-import { isBfWork, isBfInstance, isBfItem } from "utilities/Bibframe"
 
 /**
  * Shows the resources title
  */
-const ResourceTitle = ({ resource }) => {
-  let badge = null
-  if (isBfWork(resource.classes)) badge = "WORK"
-  if (isBfInstance(resource.classes)) badge = "INSTANCE"
-  if (isBfItem(resource.classes)) badge = "ITEM"
-
-  return (
-    <React.Fragment>
-      <span className="resource-label">{resource.label}</span>
-      {badge && <span className="badge bg-secondary ms-2">{badge}</span>}
-    </React.Fragment>
-  )
-}
+const ResourceTitle = ({ resource }) => (
+  <span className="resource-label">{resource.label}</span>
+)
 
 ResourceTitle.propTypes = {
   resource: PropTypes.object.isRequired,

--- a/src/components/search/SearchResultRow.jsx
+++ b/src/components/search/SearchResultRow.jsx
@@ -11,6 +11,7 @@ import useResource from "hooks/useResource"
 import useAlerts from "hooks/useAlerts"
 import { hasSearchRelationships } from "selectors/relationships"
 import RelationshipResults from "./RelationshipResults"
+import { resourceToName } from "utilities/Utilities"
 
 /**
  * Generates HTML row of all search results
@@ -81,7 +82,9 @@ const SearchResultRow = ({
         <td>
           <ul className="list-unstyled">
             {row.type?.map((type) => (
-              <li key={type}>{type}</li>
+              <li key={type}>
+                {resourceToName(type)} ({type})
+              </li>
             ))}
           </ul>
         </td>

--- a/src/components/search/SearchResultRow.jsx
+++ b/src/components/search/SearchResultRow.jsx
@@ -87,15 +87,7 @@ const SearchResultRow = ({
                 <ResourceTitle
                   resource={{
                     classes: [type],
-                    label: (
-                      <>
-                        {resourceToName(type)} (
-                        <a href={type} target="_blank" rel="noreferrer">
-                          {type}
-                        </a>
-                        )
-                      </>
-                    ),
+                    label: <>{resourceToName(type)}</>,
                   }}
                 />
               </li>

--- a/src/components/search/SearchResultRow.jsx
+++ b/src/components/search/SearchResultRow.jsx
@@ -83,7 +83,7 @@ const SearchResultRow = ({
           <ul className="list-unstyled">
             {row.type?.map((type) => (
               <li key={type}>
-                {resourceToName(type)} ({type})
+                {resourceToName(type)} (<a href={type} target="_blank" rel="noreferrer">{type}</a>)
               </li>
             ))}
           </ul>

--- a/src/components/search/SearchResultRow.jsx
+++ b/src/components/search/SearchResultRow.jsx
@@ -12,6 +12,7 @@ import useAlerts from "hooks/useAlerts"
 import { hasSearchRelationships } from "selectors/relationships"
 import RelationshipResults from "./RelationshipResults"
 import { resourceToName } from "utilities/Utilities"
+import ResourceTitle from "components/editor/ResourceTitle"
 
 /**
  * Generates HTML row of all search results
@@ -83,7 +84,20 @@ const SearchResultRow = ({
           <ul className="list-unstyled">
             {row.type?.map((type) => (
               <li key={type}>
-                {resourceToName(type)} (<a href={type} target="_blank" rel="noreferrer">{type}</a>)
+                <ResourceTitle
+                  resource={{
+                    classes: [type],
+                    label: (
+                      <>
+                        {resourceToName(type)} (
+                        <a href={type} target="_blank" rel="noreferrer">
+                          {type}
+                        </a>
+                        )
+                      </>
+                    ),
+                  }}
+                />
               </li>
             ))}
           </ul>


### PR DESCRIPTION
## Why was this change made?

Fixes #97 

Updates type label in search results.

<img width="1879" height="286" alt="Screenshot 2026-06-15 at 8 40 30 AM" src="https://github.com/user-attachments/assets/91431f18-c557-461c-ab56-13c902b748d1" />


## How was this change tested?



## Which documentation and/or configurations were updated?



