### PR TITLE
Remove group column from search results

### DIFF
--- a/__tests__/components/search/SinopiaSearchResults.test.js
+++ b/__tests__/components/search/SinopiaSearchResults.test.js
@@ -60,7 +60,6 @@ describe("<SinopiaSearchResults />", () => {
       // Search table headers
       screen.queryByText("Label / ID")
       screen.queryByText("Class")
-      screen.queryByText("Group")
       screen.getByText("Modified", { selector: "th" })
 
       // It has a sort button
@@ -75,7 +74,6 @@ describe("<SinopiaSearchResults />", () => {
       screen.queryByText(/https:\/\/api.sinopia.io\/resource\/some\/path/)
       screen.queryByText("Oct 23, 2019")
       screen.queryByText("http://schema.org/Thing")
-      screen.queryByText("Stanford University")
     })
   })
 })

--- a/__tests__/feature/loadResource.test.js
+++ b/__tests__/feature/loadResource.test.js
@@ -32,7 +32,6 @@ describe("loading saved resource", () => {
       // The result
       await screen.findByText(uri)
       screen.getByText("Fixture", { selector: "span.resource-label" })
-      screen.getByText("Stanford University")
       screen.getByText("Jul 15, 2020")
 
       // Click edit
@@ -99,7 +98,6 @@ describe("loading saved resource", () => {
       // The result
       await screen.findByText(uri)
       screen.getByText("Fixture", { selector: "span.resource-label" })
-      screen.getByText("Stanford University")
       screen.getByText("Jul 15, 2020")
 
       // Click edit

--- a/src/components/search/RelationshipResults.jsx
+++ b/src/components/search/RelationshipResults.jsx
@@ -5,7 +5,6 @@ import { selectSearchRelationships } from "selectors/relationships"
 import { getSearchResultsByUris } from "sinopiaSearch"
 import useAlerts from "hooks/useAlerts"
 import usePermissions from "hooks/usePermissions"
-import { selectGroupMap } from "selectors/groups"
 import SearchResultRow from "./SearchResultRow"
 import { addError } from "actions/errors"
 import _ from "lodash"
@@ -17,7 +16,6 @@ const RelationshipResults = ({ uri }) => {
     selectSearchRelationships(state, uri)
   )
   const { canEdit, canCreate } = usePermissions()
-  const groupMap = useSelector((state) => selectGroupMap(state))
 
   // These are results from search
   const [resourceRowMap, setResourceRowMap] = useState({})
@@ -65,7 +63,6 @@ const RelationshipResults = ({ uri }) => {
         <SearchResultRow
           key={row.uri}
           row={row}
-          groupMap={groupMap}
           canCreate={canCreate}
           canEdit={canEdit(row)}
           withRelationships={false}
@@ -79,7 +76,6 @@ const RelationshipResults = ({ uri }) => {
           <colgroup>
             <col span="1" />
             <col span="1" style={{ width: "30%" }} />
-            <col span="1" style={{ width: "15%" }} />
             <col span="1" style={{ width: "10%" }} />
             <col span="1" style={{ width: "10%" }} />
           </colgroup>

--- a/src/components/search/SearchResultRow.jsx
+++ b/src/components/search/SearchResultRow.jsx
@@ -21,7 +21,6 @@ const SearchResultRow = ({
   row,
   canEdit,
   canCreate,
-  groupMap,
   withRelationships = true,
 }) => {
   const errorKey = useAlerts()
@@ -94,7 +93,6 @@ const SearchResultRow = ({
             ))}
           </ul>
         </td>
-        <td>{groupMap[row.group] || "Unknown"}</td>
         <td>
           <LongDate datetime={row.modified} />
         </td>
@@ -124,7 +122,7 @@ const SearchResultRow = ({
       </tr>
       {showRelationships && (
         <tr className="search-no-top-border table-light">
-          <td colSpan="5" className="px-0 search-no-top-border">
+          <td colSpan="4" className="px-0 search-no-top-border">
             <RelationshipResults uri={row.uri} />
           </td>
         </tr>
@@ -137,7 +135,6 @@ SearchResultRow.propTypes = {
   row: PropTypes.object.isRequired,
   canEdit: PropTypes.bool.isRequired,
   canCreate: PropTypes.bool.isRequired,
-  groupMap: PropTypes.object.isRequired,
   withRelationships: PropTypes.bool,
 }
 

--- a/src/components/search/SearchResultRows.jsx
+++ b/src/components/search/SearchResultRows.jsx
@@ -1,10 +1,8 @@
 // Copyright 2019 Stanford University see LICENSE for license
 
 import React from "react"
-import { useSelector } from "react-redux"
 import PropTypes from "prop-types"
 import usePermissions from "hooks/usePermissions"
-import { selectGroupMap } from "selectors/groups"
 import SearchResultRow from "./SearchResultRow"
 
 /**
@@ -12,13 +10,11 @@ import SearchResultRow from "./SearchResultRow"
  */
 const SearchResultRows = ({ searchResults }) => {
   const { canEdit, canCreate } = usePermissions()
-  const groupMap = useSelector((state) => selectGroupMap(state))
 
   return searchResults.map((row) => (
     <SearchResultRow
       key={row.uri}
       row={row}
-      groupMap={groupMap}
       canCreate={canCreate}
       canEdit={canEdit(row)}
     />

--- a/src/components/search/SinopiaSearchResults.jsx
+++ b/src/components/search/SinopiaSearchResults.jsx
@@ -59,7 +59,6 @@ const SinopiaSearchResults = () => {
                 <th style={{ width: "30%" }}>
                   Class <ClassFilter />
                 </th>
-                <th style={{ width: "15%" }}>Group</th>
                 <th style={{ width: "10%" }}>Modified</th>
                 <th style={{ width: "10%" }}>
                   <SinopiaSort />


### PR DESCRIPTION
## Why was this change made?

Fixes #100 

<img width="1886" height="518" alt="Screenshot 2026-06-15 at 10 00 08 AM" src="https://github.com/user-attachments/assets/dbd4c35e-7d9a-4534-9d81-8939610001ce" />

  Source changes:
  - src/components/editor/ResourceTitle.jsx — removed badge logic and unused Bibframe imports (This may be a bit of carry over from another PR and could go away on a rebase, but leaving for now)
  - src/components/search/SearchResultRow.jsx — removed groupMap prop and the Group <td>; updated colSpan from 5 to 4
  - src/components/search/SearchResultRows.jsx — removed groupMap selector and prop
  - src/components/search/RelationshipResults.jsx — removed groupMap selector and prop; removed the group column from
  colgroup
  - src/components/search/SinopiaSearchResults.jsx — removed the <th>Group</th> header

  Test changes:
  - SinopiaSearchResults.test.js — removed "Group" header check and "Stanford University" check
  - loadResource.test.js — removed "Stanford University" checks
  - viewRelationships.test.js — removed badge assertions
  
## How was this change tested?



## Which documentation and/or configurations were updated?



