### PR TITLE
Update search_host path to the  path for JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ Start the Express web server (via `npm run dev-start`) with the following variab
 
 Full command:
 
-`SINOPIA_URI=http://localhost:8888 SINOPIA_API_BASE_URL=http://localhost/api SEARCH_HOST=http://localhost/api/search KEYCLOAK_URL=http://localhost:8888/keycloak npm run dev-start` 
+```
+SINOPIA_URI=http://localhost:8888 SINOPIA_API_BASE_URL=http://localhost/api SEARCH_HOST=http://localhost/api/search/ KEYCLOAK_URL=http://localhost:8888/keycloak npm run dev-start
+``` 
 
 Sinopia in development mode will be available at [http://localhost:8888](http://localhost:8888).
 


### PR DESCRIPTION
## Why was this change made?

The API search endpoint was updated such that `/search` returns HTML and `/search/` returns JSON - which is what is expected in sinopia.


## How was this change tested?



## Which documentation and/or configurations were updated?



