### PR TITLE
Fix resource loading after API changes

### DIFF
--- a/__tests__/actionCreators/resources.loadResource.test.js
+++ b/__tests__/actionCreators/resources.loadResource.test.js
@@ -54,8 +54,9 @@ describe("loadResource", () => {
     jest.spyOn(relationshipActionCreators, "loadRelationships")
 
     it("dispatches actions", async () => {
+      const keycloak = { token: "test-token" }
       const result = await store.dispatch(
-        loadResourceForEditor(uri, "testerrorkey")
+        loadResourceForEditor(uri, "testerrorkey", {}, keycloak)
       )
       expect(result).toBe(true)
 
@@ -85,7 +86,7 @@ describe("loadResource", () => {
         "resource",
         "87d27b05d48874c9f80cd4b7e8fc0dcc",
         uri,
-        undefined
+        keycloak
       )
 
       // loadRelationships is invoked async and do not wait for results

--- a/__tests__/actionCreators/resources.newResource.test.js
+++ b/__tests__/actionCreators/resources.newResource.test.js
@@ -43,8 +43,9 @@ describe("newResource", () => {
     const store = mockStore(createState())
 
     it("dispatches actions", async () => {
+      const keycloak = { token: "test-token" }
       const result = await store.dispatch(
-        newResource(resourceTemplateId, "testerrorkey")
+        newResource(resourceTemplateId, "testerrorkey", true, keycloak)
       )
       expect(result).toBe("abc123")
 
@@ -75,7 +76,7 @@ describe("newResource", () => {
         "template",
         "e2bb9b57c5d91394dc6f7e1d32d7a97b",
         resourceTemplateId,
-        undefined
+        keycloak
       )
     })
   })

--- a/__tests__/actionCreators/resources.test.js
+++ b/__tests__/actionCreators/resources.test.js
@@ -180,9 +180,10 @@ describe("saveResource", () => {
     const state = createState({ hasResourceWithLiteral: true })
     state.entities.subjects.t9zVwg2zO.group = "stanford"
     const store = mockStore(state)
+    const keycloak = { token: "test-token" }
 
     await store.dispatch(
-      saveResource("t9zVwg2zO", "stanford", ["cornell"], "testerror")
+      saveResource("t9zVwg2zO", "stanford", ["cornell"], "testerror", keycloak)
     )
     const actions = store.getActions()
 
@@ -205,7 +206,7 @@ describe("saveResource", () => {
       "resource",
       "3eb9f1444e9ec984fb165fc9c4de826a",
       "https://api.sinopia.io/resource/0894a8b3",
-      undefined
+      keycloak
     )
   })
 

--- a/__tests__/actionCreators/search.test.js
+++ b/__tests__/actionCreators/search.test.js
@@ -46,6 +46,7 @@ describe("fetchSinopiaSearchResults", () => {
       .fn()
       .mockResolvedValue([mockSearchResults, mockFacetResults])
     sinopiaApi.putUserHistory = jest.fn().mockResolvedValue()
+    const keycloak = { token: "test-token" }
     const store = mockStore(createState())
     await store.dispatch(
       fetchSinopiaSearchResults(
@@ -56,7 +57,8 @@ describe("fetchSinopiaSearchResults", () => {
           sortField: "label",
           sortOrder: "desc",
         },
-        "testerrorkey"
+        "testerrorkey",
+        keycloak
       )
     )
 
@@ -84,14 +86,14 @@ describe("fetchSinopiaSearchResults", () => {
       authorityUri: "urn:ld4p:sinopia",
       authorityLabel: "Sinopia resources",
       query: "*",
-      keycloak: undefined,
+      keycloak,
     })
     expect(sinopiaApi.putUserHistory).toHaveBeenCalledWith(
       "Foo McBar",
       "search",
       "e983591a38cf0e7a8d9a2a1e3251a1b6",
       '{"authorityUri":"urn:ld4p:sinopia","query":"*"}',
-      undefined
+      keycloak
     )
   })
 })
@@ -171,8 +173,6 @@ describe("fetchQASearchResults", () => {
     })
 
     it("dispatches action", async () => {
-      sinopiaApi.putUserHistory = jest.fn().mockResolvedValue()
-
       const store = mockStore(createState())
       await store.dispatch(fetchQASearchResults(query, uri, "testerrorkey"))
 
@@ -197,13 +197,6 @@ describe("fetchQASearchResults", () => {
         query,
         keycloak: undefined,
       })
-      expect(sinopiaApi.putUserHistory).toHaveBeenCalledWith(
-        "Foo McBar",
-        "search",
-        "7c944f41fb8b8bba92311b4f4f48ceb3",
-        '{"authorityUri":"urn:ld4p:qa:oclc_fast:topic","query":"*"}',
-        undefined
-      )
     })
   })
 

--- a/__tests__/actionCreators/user.test.js
+++ b/__tests__/actionCreators/user.test.js
@@ -113,10 +113,12 @@ describe("addResourceHistory()", () => {
   it("sends to API", async () => {
     sinopiaApi.putUserHistory = jest.fn().mockResolvedValue()
     const store = mockStore(createState())
+    const keycloak = { token: "test-token" }
 
     await store.dispatch(
       addResourceHistory(
-        "https://api.development.sinopia.io/resource/3f90a592-5070-4244-a2d9-47f503329e39"
+        "https://api.development.sinopia.io/resource/3f90a592-5070-4244-a2d9-47f503329e39",
+        keycloak
       )
     )
 
@@ -125,7 +127,7 @@ describe("addResourceHistory()", () => {
       "resource",
       "b7d41ce2cdf71bd8dd3198b93d5bb7bd",
       "https://api.development.sinopia.io/resource/3f90a592-5070-4244-a2d9-47f503329e39",
-      undefined
+      keycloak
     )
   })
 })
@@ -134,15 +136,16 @@ describe("addSearchHistory()", () => {
   it("sends to API", async () => {
     sinopiaApi.putUserHistory = jest.fn().mockResolvedValue()
     const store = mockStore(createState())
+    const keycloak = { token: "test-token" }
 
-    await store.dispatch(addSearchHistory("sinopia", "ants"))
+    await store.dispatch(addSearchHistory("sinopia", "ants", keycloak))
 
     expect(sinopiaApi.putUserHistory).toHaveBeenCalledWith(
       "Foo McBar",
       "search",
       "dd5b5cc7ca199ba76faf047ffb52575d",
       '{"authorityUri":"sinopia","query":"ants"}',
-      undefined
+      keycloak
     )
   })
 })

--- a/src/actionCreators/user.js
+++ b/src/actionCreators/user.js
@@ -27,7 +27,7 @@ export const loadUserData = (userId, keycloak) => (dispatch) =>
 
 const addHistory = (historyType, payload, keycloak) => (dispatch, getState) => {
   const user = selectUser(getState())
-  if (!user) return
+  if (!user || !keycloak) return
   return putUserHistory(
     user.username,
     historyType,

--- a/src/components/editor/preview/PreviewModal.jsx
+++ b/src/components/editor/preview/PreviewModal.jsx
@@ -55,7 +55,7 @@ const PreviewModal = () => {
 
   const handleCloseClick = (event) => {
     close(event)
-    dispatch(clearResource(currentResourceKey))
+    if (currentResourceKey) dispatch(clearResource(currentResourceKey))
   }
 
   const header = (

--- a/src/hooks/useResource.js
+++ b/src/hooks/useResource.js
@@ -92,9 +92,9 @@ const useResource = (
       dispatch(showModal("PreviewModal"))
     } else {
       setStatus("loading view")
-      dispatch(loadResourceForPreview(resourceURI, errorKey)).then(() => {
+      dispatch(loadResourceForPreview(resourceURI, errorKey)).then((result) => {
         setStatus("ready")
-        dispatch(showModal("PreviewModal"))
+        if (result) dispatch(showModal("PreviewModal"))
       })
     }
   }


### PR DESCRIPTION
## Why was this change made?

After changes to the API (I think, particularly the search endpoint) I was getting uncaught exceptions in sinopia when trying to load a resource, like the modal opened without the entry for a template, etc.

Not sure if this is a complete/correct fix, but it resolved the issues for me and I can now load resources.

## How was this change tested?



## Which documentation and/or configurations were updated?



