### PR TITLE
Add export to catalog confirmation

### DIFF
--- a/__tests__/actionCreators/transfer.test.js
+++ b/__tests__/actionCreators/transfer.test.js
@@ -16,13 +16,16 @@ const resourceUri =
 
 describe("transfer", () => {
   describe("successful", () => {
-    it("dispatches actions to add user", async () => {
+    it("dispatches ADD_SUCCESS with the resource URI", async () => {
       sinopiaApi.postTransfer = jest.fn().mockResolvedValue()
       const store = mockStore(createState())
       await store.dispatch(transfer(resourceUri, undefined, "testerrorkey"))
 
-      expect(store.getActions()).toHaveLength(0)
       expect(sinopiaApi.postTransfer).toHaveBeenCalledWith(resourceUri, undefined)
+      expect(store.getActions()).toHaveAction("ADD_SUCCESS", {
+        successKey: "testerrorkey",
+        message: `Export of ${resourceUri} requested. You will be notified by email once processed.`,
+      })
     })
   })
   describe("failure", () => {

--- a/__tests__/components/alerts/ContextSuccess.test.js
+++ b/__tests__/components/alerts/ContextSuccess.test.js
@@ -1,0 +1,68 @@
+// Copyright 2019 Stanford University see LICENSE for license
+
+import React from "react"
+import { screen } from "@testing-library/react"
+import ContextSuccess from "components/alerts/ContextSuccess"
+import { createStore, renderComponent } from "testUtils"
+import { createState } from "stateUtils"
+
+let mockKeycloak
+
+jest.mock("keycloak-js", () => {
+  mockKeycloak = {
+    init: jest.fn(() => Promise.resolve(true)),
+    token: "Secret-Token",
+    authenticated: true,
+    isTokenExpired: jest.fn(),
+    updateToken: jest.fn(),
+    tokenParsed: {
+      preferred_username: "Foo McBar",
+    },
+  }
+
+  return jest.fn().mockImplementation(() => mockKeycloak)
+})
+
+describe("<ContextSuccess />", () => {
+  it("renders nothing when there are no success messages", () => {
+    const store = createStore(createState())
+    const { container } = renderComponent(<ContextSuccess />, store)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it("renders nothing when the success list for the context key is empty", () => {
+    const state = createState()
+    state.editor.successes = { testErrorKey: [] }
+    const store = createStore(state)
+    const { container } = renderComponent(<ContextSuccess />, store)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it("renders success messages for the context key", () => {
+    const state = createState()
+    state.editor.successes = { testErrorKey: ["Saved successfully"] }
+    const store = createStore(state)
+    renderComponent(<ContextSuccess />, store)
+    expect(screen.getByRole("alert")).toHaveClass("alert-success")
+    expect(screen.getByText("Saved successfully")).toBeInTheDocument()
+  })
+
+  it("renders multiple success messages", () => {
+    const state = createState()
+    state.editor.successes = {
+      testErrorKey: ["Resource saved", "Export complete"],
+    }
+    const store = createStore(state)
+    renderComponent(<ContextSuccess />, store)
+    expect(screen.getByText("Resource saved")).toBeInTheDocument()
+    expect(screen.getByText("Export complete")).toBeInTheDocument()
+  })
+
+  it("does not render messages belonging to a different key", () => {
+    const state = createState()
+    state.editor.successes = { otherKey: ["Should not appear"] }
+    const store = createStore(state)
+    const { container } = renderComponent(<ContextSuccess />, store)
+    expect(container.firstChild).toBeNull()
+  })
+})

--- a/__tests__/components/alerts/SuccessAlert.test.js
+++ b/__tests__/components/alerts/SuccessAlert.test.js
@@ -1,0 +1,21 @@
+// Copyright 2019 Stanford University see LICENSE for license
+
+import React from "react"
+import { render } from "@testing-library/react"
+import SuccessAlert from "components/alerts/SuccessAlert"
+
+describe("<SuccessAlert />", () => {
+  it("renders nothing when messages is empty", () => {
+    const { container } = render(<SuccessAlert messages={[]} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it("renders each message as a paragraph inside an alert-success wrapper", () => {
+    const { getByRole, getByText } = render(
+      <SuccessAlert messages={["Resource saved", "Export complete"]} />
+    )
+    expect(getByRole("alert")).toHaveClass("alert-success")
+    expect(getByText("Resource saved")).toBeInTheDocument()
+    expect(getByText("Export complete")).toBeInTheDocument()
+  })
+})

--- a/__tests__/components/alerts/SuccessWrapper.test.js
+++ b/__tests__/components/alerts/SuccessWrapper.test.js
@@ -1,0 +1,18 @@
+// Copyright 2019 Stanford University see LICENSE for license
+
+import React from "react"
+import { render } from "@testing-library/react"
+import SuccessWrapper from "components/alerts/SuccessWrapper"
+
+describe("<SuccessWrapper />", () => {
+  it("renders children inside an alert-success div", () => {
+    const { getByRole } = render(
+      <SuccessWrapper>
+        <p>Saved successfully</p>
+      </SuccessWrapper>
+    )
+    const alert = getByRole("alert")
+    expect(alert).toHaveClass("alert-success")
+    expect(alert).toHaveTextContent("Saved successfully")
+  })
+})

--- a/__tests__/feature/editing/transfer.test.js
+++ b/__tests__/feature/editing/transfer.test.js
@@ -47,6 +47,9 @@ describe("transfer saved bf:Instance when user belongs to a transfer group", () 
     const transferBtn = screen.getByText("Export to Catalog")
     fireEvent.click(transferBtn)
     await screen.findByText("Requesting")
+    await screen.findByText(
+      `Export of ${bfUri} requested. You will be notified by email once processed.`
+    )
   }, 15000)
 })
 

--- a/__tests__/reducers/errors.test.js
+++ b/__tests__/reducers/errors.test.js
@@ -2,7 +2,9 @@
 
 import {
   addError,
+  addSuccess,
   clearErrors,
+  clearSuccesses,
   hideValidationErrors,
   showValidationErrors,
 } from "reducers/errors"
@@ -11,7 +13,9 @@ import { createReducer } from "reducers/index"
 
 const handlers = {
   ADD_ERROR: addError,
+  ADD_SUCCESS: addSuccess,
   CLEAR_ERRORS: clearErrors,
+  CLEAR_SUCCESSES: clearSuccesses,
   HIDE_VALIDATION_ERRORS: hideValidationErrors,
   SHOW_VALIDATION_ERRORS: showValidationErrors,
 }
@@ -96,6 +100,71 @@ describe("hideValidationErrors()", () => {
     const newState = reducer(oldState, action)
 
     expect(newState.resourceValidation.u230f67).toBeFalsy()
+  })
+})
+
+describe("addSuccess()", () => {
+  it("adds a message when no successes exist yet", () => {
+    const oldState = { successes: {} }
+
+    const action = {
+      type: "ADD_SUCCESS",
+      payload: { successKey: "abc123", message: "Resource saved" },
+    }
+
+    const newState = reducer(oldState, action)
+    expect(newState.successes).toStrictEqual({
+      abc123: ["Resource saved"],
+    })
+  })
+
+  it("appends a message to existing successes for the same key", () => {
+    const oldState = {
+      successes: { abc123: ["First success"] },
+    }
+
+    const action = {
+      type: "ADD_SUCCESS",
+      payload: { successKey: "abc123", message: "Second success" },
+    }
+
+    const newState = reducer(oldState, action)
+    expect(newState.successes.abc123).toStrictEqual([
+      "First success",
+      "Second success",
+    ])
+  })
+
+  it("does not affect successes under other keys", () => {
+    const oldState = {
+      successes: { other: ["Unrelated success"] },
+    }
+
+    const action = {
+      type: "ADD_SUCCESS",
+      payload: { successKey: "abc123", message: "Resource saved" },
+    }
+
+    const newState = reducer(oldState, action)
+    expect(newState.successes.other).toStrictEqual(["Unrelated success"])
+  })
+})
+
+describe("clearSuccesses()", () => {
+  it("sets successes to empty for a given successKey", () => {
+    const oldState = {
+      successes: {
+        abc123: ["Resource saved", "Another success"],
+      },
+    }
+
+    const action = {
+      type: "CLEAR_SUCCESSES",
+      payload: "abc123",
+    }
+
+    const newState = reducer(oldState, action)
+    expect(newState.successes.abc123).toStrictEqual([])
   })
 })
 

--- a/__tests__/selectors/errors.test.js
+++ b/__tests__/selectors/errors.test.js
@@ -2,6 +2,7 @@ import { createState } from "stateUtils"
 import {
   displayResourceValidations,
   selectErrors,
+  selectSuccesses,
   selectValidationErrors,
 } from "selectors/errors"
 
@@ -42,6 +43,25 @@ describe("selectErrors()", () => {
     expect(Object.keys(errors).length).toBe(2)
     expect(errors.dairdj42u).toEqual(["error 3"])
     expect(errors.fQMouMqB0).toEqual(["error 4"])
+  })
+})
+
+describe("selectSuccesses()", () => {
+  it("returns undefined when no successes exist", () => {
+    const state = createState()
+    expect(selectSuccesses(state, "abc123")).toBeUndefined()
+  })
+
+  it("returns messages for a given success key", () => {
+    const state = createState()
+    state.editor.successes = { abc123: ["Saved successfully"] }
+    expect(selectSuccesses(state, "abc123")).toEqual(["Saved successfully"])
+  })
+
+  it("returns undefined for a key with no messages", () => {
+    const state = createState()
+    state.editor.successes = { other: ["Something else"] }
+    expect(selectSuccesses(state, "abc123")).toBeUndefined()
   })
 })
 

--- a/src/actionCreators/transfer.js
+++ b/src/actionCreators/transfer.js
@@ -1,12 +1,22 @@
 import { postTransfer } from "../sinopiaApi"
-import { addError } from "actions/errors"
+import { addError, addSuccess } from "actions/errors"
 
-export const transfer = (resourceUri, keycloak, errorKey) => (dispatch) => {
-  postTransfer(resourceUri, keycloak).catch((err) => {
-    dispatch(
-      addError(errorKey, `Error requesting transfer: ${err.message || err}`)
-    )
-  })
-}
+export const transfer =
+  (resourceUri, keycloak, errorKey) => (dispatch) => {
+    return postTransfer(resourceUri, keycloak)
+      .then(() => {
+        dispatch(
+          addSuccess(
+            errorKey,
+            `Export of ${resourceUri} requested. You will be notified by email once processed.`
+          )
+        )
+      })
+      .catch((err) => {
+        dispatch(
+          addError(errorKey, `Error requesting transfer: ${err.message || err}`)
+        )
+      })
+  }
 
 export const noop = () => {}

--- a/src/actions/errors.js
+++ b/src/actions/errors.js
@@ -8,6 +8,16 @@ export const clearErrors = (errorKey) => ({
   payload: errorKey,
 })
 
+export const addSuccess = (successKey, message) => ({
+  type: "ADD_SUCCESS",
+  payload: { successKey, message },
+})
+
+export const clearSuccesses = (successKey) => ({
+  type: "CLEAR_SUCCESSES",
+  payload: successKey,
+})
+
 export const hideValidationErrors = (resourceKey) => ({
   type: "HIDE_VALIDATION_ERRORS",
   payload: resourceKey,

--- a/src/components/alerts/ContextSuccess.jsx
+++ b/src/components/alerts/ContextSuccess.jsx
@@ -1,0 +1,19 @@
+// Copyright 2019 Stanford University see LICENSE for license
+
+import React from "react"
+import { useSelector } from "react-redux"
+import { selectSuccesses } from "selectors/errors"
+import useAlerts from "hooks/useAlerts"
+import SuccessAlert from "./SuccessAlert"
+import _ from "lodash"
+
+const ContextSuccess = () => {
+  const successKey = useAlerts()
+  const messages = useSelector((state) => selectSuccesses(state, successKey))
+
+  if (_.isEmpty(messages)) return null
+
+  return <SuccessAlert messages={messages} />
+}
+
+export default ContextSuccess

--- a/src/components/alerts/SuccessAlert.jsx
+++ b/src/components/alerts/SuccessAlert.jsx
@@ -1,0 +1,29 @@
+// Copyright 2019 Stanford University see LICENSE for license
+
+import React, { useRef, useState, useLayoutEffect } from "react"
+import PropTypes from "prop-types"
+import SuccessWrapper from "./SuccessWrapper"
+import _ from "lodash"
+
+const SuccessAlert = ({ messages }) => {
+  const ref = useRef()
+  const [lastMessages, setLastMessages] = useState(false)
+
+  useLayoutEffect(() => {
+    if (_.isEqual(lastMessages, messages)) return
+    if (!_.isEmpty(messages)) window.scrollTo(0, ref.current.offsetTop)
+    setLastMessages([...messages])
+  }, [messages, lastMessages])
+
+  if (_.isEmpty(messages)) return null
+
+  const messageText = messages.map((message) => <p key={message}>{message}</p>)
+
+  return <SuccessWrapper ref={ref}>{messageText}</SuccessWrapper>
+}
+
+SuccessAlert.propTypes = {
+  messages: PropTypes.array.isRequired,
+}
+
+export default SuccessAlert

--- a/src/components/alerts/SuccessWrapper.jsx
+++ b/src/components/alerts/SuccessWrapper.jsx
@@ -1,0 +1,24 @@
+// Copyright 2019 Stanford University see LICENSE for license
+
+import React, { forwardRef } from "react"
+import PropTypes from "prop-types"
+
+const SuccessWrapper = forwardRef(({ children }, ref) => (
+  <div ref={ref} className="row">
+    <div className="col" style={{ marginTop: "10px" }}>
+      <div className="alert alert-success" role="alert">
+        {children}
+      </div>
+    </div>
+  </div>
+))
+SuccessWrapper.displayName = "SuccessWrapper"
+
+SuccessWrapper.propTypes = {
+  children: PropTypes.oneOfType([
+    PropTypes.node,
+    PropTypes.arrayOf(PropTypes.node),
+  ]),
+}
+
+export default SuccessWrapper

--- a/src/components/editor/Editor.jsx
+++ b/src/components/editor/Editor.jsx
@@ -8,6 +8,7 @@ import Header from "../Header"
 import GroupChoiceModal from "./GroupChoiceModal"
 import EditorActions from "./EditorActions"
 import ErrorMessages from "./ErrorMessages"
+import ContextSuccess from "components/alerts/ContextSuccess"
 import ResourcesNav from "./ResourcesNav"
 import {
   displayResourceValidations,
@@ -81,6 +82,7 @@ const Editor = (props) => {
         <Header triggerEditorMenu={props.triggerHandleOffsetMenu} />
         <EditorPreviewModal />
         <ContextAlert />
+        <ContextSuccess />
         {displayErrors && hasValidationErrors && (
           <ErrorMessages resourceKey={resourceKey} />
         )}

--- a/src/reducers/errors.js
+++ b/src/reducers/errors.js
@@ -29,6 +29,25 @@ export const clearErrors = (state, action) => ({
   },
 })
 
+export const addSuccess = (state, action) => ({
+  ...state,
+  successes: {
+    ...state.successes,
+    [action.payload.successKey]: [
+      ...(state.successes?.[action.payload.successKey] || []),
+      action.payload.message,
+    ],
+  },
+})
+
+export const clearSuccesses = (state, action) => ({
+  ...state,
+  successes: {
+    ...state.successes,
+    [action.payload]: [],
+  },
+})
+
 /**
  * Close modals and show validation errors
  * @param {Object} state the previous redux state

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -46,6 +46,8 @@ import {
   addError,
   clearErrors,
   showValidationErrors,
+  addSuccess,
+  clearSuccesses,
 } from "./errors"
 import { showModal, hideModal, showLangModal, showMarcModal } from "./modals"
 import { showCopyNewMessage } from "./messages"
@@ -106,7 +108,9 @@ const authHandlers = {
 
 const editorHandlers = {
   ADD_ERROR: addError,
+  ADD_SUCCESS: addSuccess,
   CLEAR_ERRORS: clearErrors,
+  CLEAR_SUCCESSES: clearSuccesses,
   CLEAR_PENDING_RESOURCE_TEMPLATE_SELECTION:
     clearPendingResourceTemplateSelection,
   CLEAR_RESOURCE: clearResourceFromEditor,

--- a/src/selectors/errors.js
+++ b/src/selectors/errors.js
@@ -20,6 +20,12 @@ export const hasValidationErrors = (state, resourceKey) => {
  */
 export const selectErrors = (state, errorKey) => state.editor.errors[errorKey]
 
+/**
+ * @returns {Array} the success messages for a given success key
+ */
+export const selectSuccesses = (state, successKey) =>
+  state.editor.successes?.[successKey]
+
 export const selectValidationErrors = (state, resourceKey) => {
   const subject = selectSubject(state, resourceKey)
   if (subject == null || !subject.descWithErrorPropertyKeys) return []


### PR DESCRIPTION
## Why was this change made?

Fixes #60 

This adds success alert messaging machinery along side error alerting. And then adds a message when export to catalog is successful.

## How was this change tested?



## Which documentation and/or configurations were updated?



