### PR TITLE
Add a Service to query LOC SuggestService

### DIFF
--- a/__tests__/utilities/LocSuggest.test.js
+++ b/__tests__/utilities/LocSuggest.test.js
@@ -1,0 +1,59 @@
+import suggest from "utilities/LocSuggest"
+
+const mockResponse = [
+  "potato",
+  ["Potatoes", "Potato chips"],
+  ["Potatoes (May Subd Geog)", "Potato chips (May Subd Geog)"],
+  [
+    "http://id.loc.gov/authorities/subjects/sh85105062",
+    "http://id.loc.gov/authorities/subjects/sh85105063",
+  ],
+]
+
+describe("suggest()", () => {
+  it("fetches results with default offset", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockResponse),
+    })
+
+    const result = await suggest("potato", "SimpleType")
+
+    expect(result).toEqual(mockResponse)
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://id.loc.gov/authorities/subjects/suggest2/?q=potato&rdftype=SimpleType&count=25&offset=0&searchtype=left"
+    )
+  })
+
+  it("passes offset parameter", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockResponse),
+    })
+
+    await suggest("potato", "ComplexSubject", 25)
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://id.loc.gov/authorities/subjects/suggest2/?q=potato&rdftype=ComplexSubject&count=25&offset=25&searchtype=left"
+    )
+  })
+
+  it("throws on non-ok response", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      statusText: "Service Unavailable",
+    })
+
+    await expect(suggest("potato", "SimpleType")).rejects.toThrow(
+      "LOC Suggest Service returned Service Unavailable"
+    )
+  })
+
+  it("throws on fetch failure", async () => {
+    global.fetch = jest.fn().mockRejectedValue(new Error("Network error"))
+
+    await expect(suggest("potato", "SimpleType")).rejects.toThrow(
+      "Network error"
+    )
+  })
+})

--- a/src/Config.js
+++ b/src/Config.js
@@ -117,6 +117,13 @@ class Config {
   static get scriptShifterUrl() {
     return process.env.SCRIPT_SHIFTER_URL || "https://bibframe.org/scriptshifter"
   }
+
+  static get locSuggestBaseUrl() {
+    return (
+      process.env.LOC_SUGGEST_BASE_URL ||
+      "https://id.loc.gov/authorities/subjects/suggest2/"
+    )
+  }
 }
 
 export default Config

--- a/src/utilities/LocSuggest.js
+++ b/src/utilities/LocSuggest.js
@@ -1,5 +1,4 @@
-const LOC_SUGGEST_BASE_URL =
-  "https://id.loc.gov/authorities/subjects/suggest2/"
+import Config from "Config"
 
 /**
  * Queries the LOC Suggest Service.
@@ -17,7 +16,7 @@ const suggest = (query, type, offset = 0) => {
     searchtype: "left",
   })
 
-  return fetch(`${LOC_SUGGEST_BASE_URL}?${urlParams}`)
+  return fetch(`${Config.locSuggestBaseUrl}?${urlParams}`)
     .then((resp) => {
       if (!resp.ok)
         throw new Error(`LOC Suggest Service returned ${resp.statusText}`)

--- a/src/utilities/LocSuggest.js
+++ b/src/utilities/LocSuggest.js
@@ -1,0 +1,34 @@
+const LOC_SUGGEST_BASE_URL =
+  "https://id.loc.gov/authorities/subjects/suggest2/"
+
+/**
+ * Queries the LOC Suggest Service.
+ * @param {string} query - The search string
+ * @param {string} type - Either "SimpleType" or "ComplexSubject"
+ * @param {number} [offset=0] - Pagination offset
+ * @return {Promise<Object>} JSON results from the LOC Suggest Service
+ */
+const suggest = (query, type, offset = 0) => {
+  const urlParams = new URLSearchParams({
+    q: query,
+    rdftype: type,
+    count: 25,
+    offset,
+    searchtype: "left",
+  })
+
+  return fetch(`${LOC_SUGGEST_BASE_URL}?${urlParams}`)
+    .then((resp) => {
+      if (!resp.ok)
+        throw new Error(`LOC Suggest Service returned ${resp.statusText}`)
+      return resp.json()
+    })
+    .catch((err) => {
+      console.error(
+        `Error querying LOC Suggest Service: ${err.message || err}`
+      )
+      throw err
+    })
+}
+
+export default suggest


### PR DESCRIPTION
## Why was this change made?

Part of #79 

Add a service for querying LOC Suggest Service by type (SimpleType or ComplexSubject).

## How was this change tested?



## Which documentation and/or configurations were updated?



