### PR TITLE
Add service to fetch subject heading details

### DIFF
--- a/__tests__/utilities/LocSubjectDetails.test.js
+++ b/__tests__/utilities/LocSubjectDetails.test.js
@@ -1,0 +1,149 @@
+import fetchSubjectDetails from "utilities/LocSubjectDetails"
+
+const SIMPLE_RDF = `<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF
+  xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+  xmlns:madsrdf="http://www.loc.gov/mads/rdf/v1#"
+  xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+>
+  <madsrdf:Topic rdf:about="http://id.loc.gov/authorities/subjects/sh85105062">
+    <madsrdf:authoritativeLabel>Potatoes</madsrdf:authoritativeLabel>
+    <skos:prefLabel>Potatoes</skos:prefLabel>
+    <madsrdf:note>Includes works on the potato plant and its uses.</madsrdf:note>
+  </madsrdf:Topic>
+</rdf:RDF>`
+
+const NESTED_RDF = `<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF
+  xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+  xmlns:madsrdf="http://www.loc.gov/mads/rdf/v1#"
+  xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+>
+  <madsrdf:ComplexSubject rdf:about="http://id.loc.gov/authorities/subjects/sh2008110277">
+    <madsrdf:authoritativeLabel>Puppets--Political aspects</madsrdf:authoritativeLabel>
+    <madsrdf:componentList>
+      <rdf:Description>
+        <rdf:first rdf:resource="http://id.loc.gov/authorities/subjects/sh85105062"/>
+      </rdf:Description>
+    </madsrdf:componentList>
+  </madsrdf:ComplexSubject>
+</rdf:RDF>`
+
+const MULTIPLE_LABELS_RDF = `<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF
+  xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+  xmlns:madsrdf="http://www.loc.gov/mads/rdf/v1#"
+>
+  <madsrdf:Topic rdf:about="http://id.loc.gov/authorities/subjects/sh85105062">
+    <madsrdf:variantLabel>Potato</madsrdf:variantLabel>
+    <madsrdf:variantLabel>Irish potato</madsrdf:variantLabel>
+    <madsrdf:authoritativeLabel>Potatoes</madsrdf:authoritativeLabel>
+  </madsrdf:Topic>
+</rdf:RDF>`
+
+const MULTIPLE_RESOURCES_RDF = `<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF
+  xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+  xmlns:madsrdf="http://www.loc.gov/mads/rdf/v1#"
+>
+  <madsrdf:Topic rdf:about="http://id.loc.gov/authorities/subjects/sh85105062">
+    <madsrdf:authoritativeLabel>Potatoes</madsrdf:authoritativeLabel>
+  </madsrdf:Topic>
+  <madsrdf:Topic rdf:about="http://id.loc.gov/authorities/subjects/sh85105063">
+    <madsrdf:authoritativeLabel>Potato chips</madsrdf:authoritativeLabel>
+  </madsrdf:Topic>
+</rdf:RDF>`
+
+const mockRdfResponse = (xmlText) =>
+  jest.fn().mockResolvedValue({
+    ok: true,
+    text: () => Promise.resolve(xmlText),
+  })
+
+describe("fetchSubjectDetails()", () => {
+  it("fetches the correct URL", async () => {
+    global.fetch = mockRdfResponse(SIMPLE_RDF)
+
+    await fetchSubjectDetails("sh85105062")
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://id.loc.gov/authorities/subjects/sh85105062.rdf"
+    )
+  })
+
+  it("strips namespace prefixes from element and attribute names", async () => {
+    global.fetch = mockRdfResponse(SIMPLE_RDF)
+
+    const result = await fetchSubjectDetails("sh85105062")
+
+    expect(result.type).toBe("Topic")
+    expect(result.about).toBe(
+      "http://id.loc.gov/authorities/subjects/sh85105062"
+    )
+    expect(result.authoritativeLabel).toBe("Potatoes")
+    expect(result.prefLabel).toBe("Potatoes")
+    expect(result.note).toBe("Includes works on the potato plant and its uses.")
+  })
+
+  it("collects repeated sibling elements into an array", async () => {
+    global.fetch = mockRdfResponse(MULTIPLE_LABELS_RDF)
+
+    const result = await fetchSubjectDetails("sh85105062")
+
+    expect(result.variantLabel).toEqual(["Potato", "Irish potato"])
+    expect(result.authoritativeLabel).toBe("Potatoes")
+  })
+
+  it("preserves hierarchy for nested elements", async () => {
+    global.fetch = mockRdfResponse(NESTED_RDF)
+
+    const result = await fetchSubjectDetails("sh2008110277")
+
+    expect(result.type).toBe("ComplexSubject")
+    expect(result.authoritativeLabel).toBe("Puppets--Political aspects")
+    expect(result.componentList).toEqual({
+      Description: {
+        first: { resource: "http://id.loc.gov/authorities/subjects/sh85105062" },
+      },
+    })
+  })
+
+  it("returns a single object when the RDF has one top-level resource", async () => {
+    global.fetch = mockRdfResponse(SIMPLE_RDF)
+
+    const result = await fetchSubjectDetails("sh85105062")
+
+    expect(Array.isArray(result)).toBe(false)
+    expect(result).toHaveProperty("authoritativeLabel")
+  })
+
+  it("returns an array when the RDF has multiple top-level resources", async () => {
+    global.fetch = mockRdfResponse(MULTIPLE_RESOURCES_RDF)
+
+    const result = await fetchSubjectDetails("sh85105062")
+
+    expect(Array.isArray(result)).toBe(true)
+    expect(result).toHaveLength(2)
+    expect(result[0].authoritativeLabel).toBe("Potatoes")
+    expect(result[1].authoritativeLabel).toBe("Potato chips")
+  })
+
+  it("throws on non-ok response", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      statusText: "Not Found",
+    })
+
+    await expect(fetchSubjectDetails("sh9999999")).rejects.toThrow(
+      "LOC subject details returned Not Found"
+    )
+  })
+
+  it("throws on fetch failure", async () => {
+    global.fetch = jest.fn().mockRejectedValue(new Error("Network error"))
+
+    await expect(fetchSubjectDetails("sh85105062")).rejects.toThrow(
+      "Network error"
+    )
+  })
+})

--- a/src/Config.js
+++ b/src/Config.js
@@ -124,6 +124,13 @@ class Config {
       "https://id.loc.gov/authorities/subjects/suggest2/"
     )
   }
+
+  static get locSubjectUrl() {
+    return (
+      process.env.LOC_SUBJECT_URL ||
+      "https://id.loc.gov/authorities/subjects/"
+    )
+  }
 }
 
 export default Config

--- a/src/utilities/LocSubjectDetails.js
+++ b/src/utilities/LocSubjectDetails.js
@@ -1,0 +1,72 @@
+import Config from "Config"
+
+/**
+ * Recursively converts an XML element to a plain JS object.
+ * Element and attribute names are stripped of their namespace prefix so that,
+ * e.g., `madsrdf:authoritativeLabel` becomes `authoritativeLabel`.
+ * When the same local name appears more than once the values are collected
+ * into an array, preserving hierarchy for nested elements.
+ *
+ * @param {Element} el
+ * @returns {Object}
+ */
+const elementToJson = (el) => {
+  const obj = {}
+
+  for (const attr of el.attributes) {
+    obj[attr.localName] = attr.value
+  }
+
+  for (const child of el.children) {
+    const key = child.localName
+    const value =
+      child.children.length > 0 || child.attributes.length > 0
+        ? elementToJson(child)
+        : child.textContent
+
+    if (Object.prototype.hasOwnProperty.call(obj, key)) {
+      if (!Array.isArray(obj[key])) obj[key] = [obj[key]]
+      obj[key].push(value)
+    } else {
+      obj[key] = value
+    }
+  }
+
+  return obj
+}
+
+/**
+ * Fetches the RDF record for an LOC subject and returns a JSON representation
+ * with namespace prefixes removed from all field names.
+ *
+ * @param {string} id - The LOC subject identifier, e.g. "sh2008110277"
+ * @returns {Promise<Object|Object[]>} Parsed JSON. A single top-level resource
+ *   is returned as an object; multiple top-level resources as an array.
+ */
+const fetchSubjectDetails = (id) =>
+  fetch(`${Config.locSubjectUrl}${id}.rdf`)
+    .then((resp) => {
+      if (!resp.ok)
+        throw new Error(`LOC subject details returned ${resp.statusText}`)
+      return resp.text()
+    })
+    .then((xmlText) => {
+      const doc = new DOMParser().parseFromString(xmlText, "application/xml")
+      const parseError = doc.querySelector("parsererror")
+      if (parseError)
+        throw new Error(`Failed to parse RDF: ${parseError.textContent}`)
+
+      const resources = Array.from(doc.documentElement.children).map(
+        (child) => ({ type: child.localName, ...elementToJson(child) })
+      )
+
+      return resources.length === 1 ? resources[0] : resources
+    })
+    .catch((err) => {
+      console.error(
+        `Error fetching LOC subject details: ${err.message || err}`
+      )
+      throw err
+    })
+
+export default fetchSubjectDetails


### PR DESCRIPTION
## Why was this change made?

Part of #79 

Add a service for getting the details of a subject heading by ID:
  - Fetches ${Config.locSubjectUrl}${id}.rdf
  - Parses RDF/XML with DOMParser, using localName throughout so madsrdf:authoritativeLabel → authoritativeLabel, rdf:about → about, etc.
  - Recurses into nested elements to preserve hierarchy; duplicate sibling keys become arrays
  - Each top-level <rdf:RDF> child becomes { type: "Topic", ...fields } (the type uses localName of the element tag)
  - Returns a single object if there's one top-level resource, an array if there are multiple

## How was this change tested?

Unit

## Which documentation and/or configurations were updated?



