### PR TITLE
Make sure the text entry has focus when Choose Resource Template opens

### DIFF
--- a/src/components/InputTemplate.jsx
+++ b/src/components/InputTemplate.jsx
@@ -1,6 +1,6 @@
 // Copyright 2019 Stanford University see LICENSE for license
 
-import React, { useState, useCallback, useEffect } from "react"
+import React, { useState, useCallback, useEffect, useRef } from "react"
 import PropTypes from "prop-types"
 import { Typeahead, withAsync } from "react-bootstrap-typeahead"
 import { getTemplateSearchResults } from "sinopiaSearch"
@@ -12,9 +12,14 @@ const InputTemplate = ({
   defaultTemplateId = null,
   ...props
 }) => {
+  const typeaheadRef = useRef(null)
   const [isLoading, setLoading] = useState(false)
   const [options, setOptions] = useState([])
   const [selected, setSelected] = useState([])
+
+  useEffect(() => {
+    typeaheadRef.current?.focus()
+  }, [])
 
   const search = useCallback((query) => {
     setLoading(true)
@@ -48,6 +53,7 @@ const InputTemplate = ({
 
   return (
     <AsyncTypeahead
+      ref={typeaheadRef}
       onSearch={search}
       onChange={change}
       options={options}


### PR DESCRIPTION
## Why was this change made?

This addresses a mild annoyance that I've found but which I believe may also be an accessibility issue by making sure that when the `Choose Resource Template` modal opens the text entry has focus.

https://github.com/user-attachments/assets/b861d1e3-2e0e-422a-b946-44128ab2914c


## How was this change tested?



## Which documentation and/or configurations were updated?



