### PR TITLE
Persist triples not covered by a template on save (#134)

### DIFF
--- a/__tests__/actionCreators/resources.persistUnusedTriples.test.js
+++ b/__tests__/actionCreators/resources.persistUnusedTriples.test.js
@@ -1,0 +1,81 @@
+import { newResourceFromDataset, saveResource } from "actionCreators/resources"
+import mockConsole from "jest-mock-console"
+import Config from "Config"
+import { createStore } from "testUtils"
+import { datasetFromN3, datasetFromJsonld } from "utilities/Utilities"
+import { selectCurrentResourceKey } from "selectors/resources"
+import { nanoid } from "nanoid"
+
+jest.mock("KeycloakContext", () => ({
+  useKeycloak: jest.fn().mockReturnValue({}),
+}))
+
+jest.mock("nanoid")
+
+// This forces Sinopia server to use fixtures.
+jest.spyOn(Config, "useResourceTemplateFixtures", "get").mockReturnValue(true)
+
+let restoreConsole = null
+beforeEach(() => {
+  // Unique ids so a real reducer-backed store doesn't collide keys.
+  let idCounter = 0
+  nanoid.mockImplementation(() => `id${idCounter++}`)
+  restoreConsole = mockConsole(["error", "debug"])
+})
+
+afterEach(() => {
+  restoreConsole()
+})
+
+// Regression test for https://github.com/blue-core-lod/sinopia_editor/issues/134
+// A resource template shapes which triples are editable, but triples the
+// template does not cover must not be stripped when the resource is saved.
+describe("saveResource with triples not covered by the template", () => {
+  const uri =
+    "http://localhost:3000/resource/b6c5f4c0-e7cd-4ca5-a20f-2a37fe1080d6"
+
+  // resourceTemplate:testing:inputs covers property1 (and others); it knows
+  // nothing about property6x, so that triple lands in unusedRDF on load.
+  const n3 = `<${uri}> <http://sinopia.io/vocabulary/hasResourceTemplate> "resourceTemplate:testing:inputs" .
+<${uri}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://sinopia.io/testing/Inputs> .
+<${uri}> <http://sinopia.io/testing/Inputs/property1> "A literal value"@en .
+`
+  const extraPredicate =
+    "http://id.loc.gov/ontologies/bibframe/uber/template1/property6x"
+  const extraTriple = `<${uri}> <${extraPredicate}> <ubertemplate1:property6> .`
+
+  it("preserves the unused triples in the saved graph", async () => {
+    const store = createStore()
+
+    // Load the resource (with the extra triple) into real state.
+    const dataset = await datasetFromN3(`${n3}${extraTriple}\n`)
+    const loaded = await store.dispatch(
+      newResourceFromDataset(dataset, uri, null, "testerror")
+    )
+    expect(loaded).toBe(true)
+
+    const resourceKey = selectCurrentResourceKey(store.getState())
+
+    // Capture the body PUT to the resource uri. Do not mock putResource, since
+    // the real GraphBuilder / serialization path is what we are exercising.
+    // Ancillary history/search fetches are absorbed by this same mock.
+    let capturedBody = null
+    global.fetch = jest.fn((url, opts) => {
+      if (url === uri) capturedBody = opts.body
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+    })
+
+    await store.dispatch(
+      saveResource(resourceKey, "stanford", [], "testerror", {
+        token: "test-token",
+      })
+    )
+
+    expect(capturedBody).not.toBeNull()
+    const { data } = JSON.parse(capturedBody)
+    const savedDataset = await datasetFromJsonld(JSON.parse(data))
+
+    // The unused triple must survive the round trip.
+    expect(savedDataset.toCanonical()).toContain(extraPredicate)
+  })
+})

--- a/__tests__/feature/unusedRDF.test.js
+++ b/__tests__/feature/unusedRDF.test.js
@@ -36,7 +36,7 @@ describe("loading RDF with unused triples", () => {
       selector: resourceHeaderSelector,
     })
 
-    screen.getByText(/Unable to load the entire resource/)
+    screen.getByText(/Some triples are not editable with this template/)
 
     // Switch to turtle
     fireEvent.change(screen.getByLabelText(/Format/), {

--- a/src/actionCreators/resources.js
+++ b/src/actionCreators/resources.js
@@ -4,7 +4,6 @@ import { showModal } from "actions/modals"
 import {
   setPendingResourceTemplateSelection,
   clearPendingResourceTemplateSelection,
-
   addProperty as addPropertyAction,
   addValue as addValueAction,
   updateLiteralValue,
@@ -18,7 +17,8 @@ import {
   loadResourceFinished,
   setResourceGroup,
   setCurrentDiff,
-  clearVersions} from "actions/resources"
+  clearVersions,
+} from "actions/resources"
 import {
   addResourceFromDataset,
   addEmptyResource,
@@ -38,6 +38,7 @@ import {
 } from "selectors/resources"
 import { newLiteralValue, newValueSubject } from "utilities/valueFactory"
 import { selectUser } from "selectors/authenticate"
+import { selectUnusedRDF } from "selectors/modals"
 import {
   addTemplateHistory as addUserTemplateHistory,
   addResourceHistory as addUserResourceHistory,
@@ -361,10 +362,18 @@ export const saveNewResource =
     const state = getState()
     const resource = selectFullSubject(state, resourceKey)
     const currentUser = selectUser(state)
+    const unusedRDF = selectUnusedRDF(state, resourceKey)
 
     dispatch(clearErrors(errorKey))
 
-    return postResource(resource, currentUser, group, editGroups, keycloak)
+    return postResource(
+      resource,
+      currentUser,
+      group,
+      editGroups,
+      keycloak,
+      unusedRDF
+    )
       .then((resourceUrl) => {
         dispatch(setBaseURL(resourceKey, resourceUrl))
         dispatch(setResourceGroup(resourceKey, group, editGroups))
@@ -389,10 +398,19 @@ export const saveResource =
     const state = getState()
     const resource = selectFullSubject(state, resourceKey)
     const currentUser = selectUser(state)
+    const unusedRDF = selectUnusedRDF(state, resourceKey)
 
     dispatch(clearErrors(errorKey))
 
-    return putResource(resource, currentUser, group, editGroups, null, keycloak)
+    return putResource(
+      resource,
+      currentUser,
+      group,
+      editGroups,
+      null,
+      keycloak,
+      unusedRDF
+    )
       .then(() => {
         dispatch(setResourceGroup(resourceKey, group, editGroups))
         dispatch(saveResourceFinished(resourceKey))

--- a/src/components/editor/UnusedRDFDisplay.jsx
+++ b/src/components/editor/UnusedRDFDisplay.jsx
@@ -44,8 +44,8 @@ const UnusedRDFDisplay = () => {
       <div className="row mb-3 gx-2">
         <div className="col-auto">
           <strong>
-            Unable to load the entire resource. The unused triples are listed
-            below.{" "}
+            Some triples are not editable with this template. However, they are
+            preserved when you save and are listed below.{" "}
           </strong>
           <label htmlFor="rdfFormat" className="col-form-label">
             View as:

--- a/src/sinopiaApi.js
+++ b/src/sinopiaApi.js
@@ -1,6 +1,10 @@
 // Copyright 2019 Stanford University see LICENSE for license
 
-import { datasetFromJsonld, jsonldFromDataset } from "utilities/Utilities"
+import {
+  datasetFromJsonld,
+  datasetFromN3,
+  jsonldFromDataset,
+} from "utilities/Utilities"
 import Config from "Config"
 /* eslint-disable node/no-unpublished-import */
 import {
@@ -139,7 +143,8 @@ export const postResource = (
   currentUser,
   group,
   editGroups,
-  keycloak
+  keycloak,
+  unusedRDF = null
 ) => {
   const newResource = { ...resource, group, editGroups }
   const url = `${Config.sinopiaApiBase}/${apiCollectionPathFor(resource)}/`
@@ -148,7 +153,8 @@ export const postResource = (
     currentUser.username,
     group,
     editGroups,
-    true
+    true,
+    unusedRDF
   ).then((body) =>
     sendResourceBody(url, body, "POST", keycloak)
       .then((resp) => checkResp(resp))
@@ -164,13 +170,20 @@ export const putResource = (
   group,
   editGroups,
   method,
-  keycloak
+  keycloak,
+  unusedRDF = null
 ) =>
-  saveBodyForResource(resource, currentUser.username, group, editGroups).then(
-    (body) =>
-      sendResourceBody(resource.uri, body, method || "PUT", keycloak).then(
-        (resp) => checkResp(resp).then(() => true)
-      )
+  saveBodyForResource(
+    resource,
+    currentUser.username,
+    group,
+    editGroups,
+    false,
+    unusedRDF
+  ).then((body) =>
+    sendResourceBody(resource.uri, body, method || "PUT", keycloak).then(
+      (resp) => checkResp(resp).then(() => true)
+    )
   )
 
 export const postMarc = (resourceUri, keycloak) => {
@@ -275,25 +288,36 @@ const saveBodyForResource = (
   user,
   group,
   editGroups,
-  useBlankNode = false
+  useBlankNode = false,
+  unusedRDF = null
 ) => {
   const dataset = new GraphBuilder(resource, useBlankNode).graph
 
-  return jsonldFromDataset(dataset).then((jsonld) =>
-    JSON.stringify({
-      data: JSON.stringify(jsonld),
-      // user,
-      // group,
-      // editGroups,
-      // templateId: resource.subjectTemplate.id,
-      // types: [resource.subjectTemplate.class],
-      // bfAdminMetadataRefs: resource.bfAdminMetadataRefs,
-      // sinopiaLocalAdminMetadataForRefs: resource.localAdminMetadataForRefs,
-      // bfItemRefs: resource.bfItemRefs,
-      // bfInstanceRefs: resource.bfInstanceRefs,
-      // bfWorkRefs: resource.bfWorkRefs,
-    })
-  )
+  // Merge back any triples that the template did not cover on load so they are
+  // preserved rather than stripped on save. See issue #134.
+  const mergeUnused = unusedRDF
+    ? datasetFromN3(unusedRDF).then((unusedDataset) =>
+        dataset.addAll(unusedDataset)
+      )
+    : Promise.resolve()
+
+  return mergeUnused
+    .then(() => jsonldFromDataset(dataset))
+    .then((jsonld) =>
+      JSON.stringify({
+        data: JSON.stringify(jsonld),
+        // user,
+        // group,
+        // editGroups,
+        // templateId: resource.subjectTemplate.id,
+        // types: [resource.subjectTemplate.class],
+        // bfAdminMetadataRefs: resource.bfAdminMetadataRefs,
+        // sinopiaLocalAdminMetadataForRefs: resource.localAdminMetadataForRefs,
+        // bfItemRefs: resource.bfItemRefs,
+        // bfInstanceRefs: resource.bfInstanceRefs,
+        // bfWorkRefs: resource.bfWorkRefs,
+      })
+    )
 }
 
 export const detectLanguage = (text, keycloak) => {


### PR DESCRIPTION
## Why was this change made?

Templates shape which triples are editable, but they were also silently
determining which triples were persisted: any triple a template didn't
cover was captured into unusedRDF on load (for display only) and then
dropped on save, since GraphBuilder rebuilds the output graph purely from
editable state.

Merge the preserved (unused) triples back into the saved graph in the save
path. saveBodyForResource now parses the stored unusedRDF and unions it into
the GraphBuilder output before serializing; saveResource/saveNewResource read
selectUnusedRDF and thread it through putResource/postResource. The async
parse lives where async already lives, and GraphBuilder stays focused on
turning editable state into triples.

In practice this only affects the PUT path (editing an existing resource).
New and copied resources set unusedRDF to null, so POST has nothing to merge,
but the value is threaded through both paths for symmetry.

Also reword the UnusedRDFDisplay banner, since these triples are no longer
lost on save.

Adds a real-store load -> save round-trip regression test.

This was authored with help from Claude. I had it wrote the test first, saw it fail, and then considered different ways to solve it. Passing around `unusedRDF` in the few places where saving was occurring seemed like the lowest impact way of not dropping the additional triples. I considered modifying `GraphBuilder.graph`, but it is synchronous and parsing the N3 is async, which would have required changing `GraphBuilder.graph` to be async and required much more changes where that getter was used. I also thought about storing an rdf-ext graph on `unusedRDF` rather than an N3 string, but it seemed like that could negatively affect how Redux state was stored, diffed, etc.  At least that's what Claude thought, and it seemed to ring some bells for me about how Redux state works.

Fixes #134

## How was this change tested?

A new unit test which passes.

I also ran under bluecore-stack, and loaded an Instance into a Work template and noted the triples that didn't fit. I made a change to the title and saved it. I saw the changed title over in bluecore-api, and noted that the *Dimensions* (which belong on the Instance) but not the Work were properly persisted because Sinopia Editor sent them to bluecore-api.

<img width="1684" height="1168" alt="Screenshot 2026-07-16 at 2 07 13 PM" src="https://github.com/user-attachments/assets/cdf08637-b4c0-4001-8248-2397ab2072d0" />

<img width="1684" height="1168" alt="Screenshot 2026-07-16 at 1 58 06 PM" src="https://github.com/user-attachments/assets/c77e292c-d749-4ef9-becf-26cb779bde27" />

<img width="1684" height="1168" alt="Screenshot 2026-07-16 at 1 58 27 PM" src="https://github.com/user-attachments/assets/d80d01c5-2615-4509-a765-5b72374ae384" />

<img width="1684" height="1168" alt="Screenshot 2026-07-16 at 2 00 11 PM" src="https://github.com/user-attachments/assets/fb5d6fd9-322e-499d-b83d-aea1344d6be8" />

Note: it is interesting to see that the Other Resource labels (e.g. Media: Microform) were overwritten, because Sinopia Editor didn't get those triples when it loaded them from bluecore-api, and the other resource was updated as part of the POST.

## Which documentation and/or configurations were updated?

n/a
