### PR TITLE
Filter out non-Blue Core relationships (#141)

### DIFF
--- a/__tests__/actionCreators/relationships.test.js
+++ b/__tests__/actionCreators/relationships.test.js
@@ -60,6 +60,34 @@ describe("loadSearchRelationships()", () => {
     expect(sinopiaApi.fetchResource).toHaveBeenCalledWith(uri)
   })
 
+  it("omits refs to non-Blue Core (external) resources", async () => {
+    const jsonld = [
+      {
+        "@id": "http://localhost:3000/resource/instance-with-items",
+        "@type": ["http://id.loc.gov/ontologies/bibframe/Instance"],
+        "http://id.loc.gov/ontologies/bibframe/hasItem": [
+          { "@id": "http://localhost:3000/resource/blue-core-item" },
+          { "@id": "http://id.loc.gov/resources/items/14300125" },
+        ],
+      },
+    ]
+    const dataset = await datasetFromJsonld(jsonld)
+    sinopiaApi.fetchResource = jest.fn().mockResolvedValue([dataset, {}])
+
+    const store = mockStore(createState())
+    await store.dispatch(loadSearchRelationships(uri))
+
+    expect(store.getActions()).toHaveAction("SET_SEARCH_RELATIONSHIPS", {
+      uri,
+      relationships: {
+        bfAdminMetadataRefs: [],
+        bfItemRefs: ["http://localhost:3000/resource/blue-core-item"],
+        bfInstanceRefs: [],
+        bfWorkRefs: [],
+      },
+    })
+  })
+
   describe("when fetchResource errors", () => {
     it("silently handles error", async () => {
       sinopiaApi.fetchResource = jest.fn().mockRejectedValue(new Error("Ooops"))

--- a/__tests__/reducers/resources.test.js
+++ b/__tests__/reducers/resources.test.js
@@ -864,6 +864,29 @@ describe("addValue()", () => {
     })
   })
 
+  describe("new uri value that is a bf Item ref to an external resource", () => {
+    it("does not add the external ref", () => {
+      const oldState = createState({ hasResourceWithLookup: true })
+
+      const newAddUriAction = {
+        ...addUriAction,
+        payload: {
+          ...addUriAction.payload,
+          value: {
+            ...addUriAction.payload.value,
+            uri: "http://id.loc.gov/resources/items/14300125",
+            propertyUri: "http://id.loc.gov/ontologies/bibframe/hasItem",
+          },
+        },
+      }
+
+      const newState = reducer(oldState.entities, newAddUriAction)
+
+      // The external item is omitted since it is not a Blue Core resource.
+      expect(newState.subjects["wihOjn-0Z"].bfItemRefs).toHaveLength(0)
+    })
+  })
+
   describe("new uri value that is a bf Admin Metadata ref", () => {
     it("updates state", () => {
       const oldState = createState({ hasResourceWithLookup: true })

--- a/__tests__/utilities/Utilities.test.js
+++ b/__tests__/utilities/Utilities.test.js
@@ -5,6 +5,7 @@ import {
   datasetFromN3,
   formatISODate,
   formatLocalDate,
+  isBlueCoreUri,
 } from "utilities/Utilities"
 import timezoneMock from "timezone-mock"
 
@@ -151,6 +152,29 @@ describe("Utilities", () => {
       expect(formatLocalDate(new Date("2019-05-14T01:01:58.135Z"))).toEqual(
         "2019-05-13"
       )
+    })
+  })
+
+  describe("isBlueCoreUri()", () => {
+    // Config.sinopiaApiBase defaults to http://localhost:3000 in tests.
+    it("is true for a URI sharing an origin with the Blue Core API", () => {
+      expect(
+        isBlueCoreUri(
+          "http://localhost:3000/resource/a5c5f4c0-e7cd-4ca5-a20f-2a37fe1080d5"
+        )
+      ).toBe(true)
+      expect(isBlueCoreUri("http://localhost:3000/instances/abc123")).toBe(true)
+    })
+
+    it("is false for an external URI", () => {
+      expect(
+        isBlueCoreUri("http://id.loc.gov/resources/items/14300125")
+      ).toBe(false)
+    })
+
+    it("is false for a non-URI value", () => {
+      expect(isBlueCoreUri("not a uri")).toBe(false)
+      expect(isBlueCoreUri("")).toBe(false)
     })
   })
 })

--- a/src/actionCreators/relationships.js
+++ b/src/actionCreators/relationships.js
@@ -2,17 +2,20 @@
 
 import { setSearchRelationships } from "actions/relationships"
 import { fetchResource } from "sinopiaApi"
+import { isBlueCoreUri } from "utilities/Utilities"
 import rdf from "rdf-ext"
 
 const BF = "http://id.loc.gov/ontologies/bibframe/"
 
 const refsFromDataset = (dataset) => {
+  // Only Blue Core resources can be fetched and displayed as relationships.
+  // External refs (e.g. bf:hasItem pointing at id.loc.gov) are omitted.
   const getObjectUris = (predicate) =>
     dataset
       .match(null, rdf.namedNode(predicate), null)
       .toArray()
       .map((quad) => quad.object.value)
-      .filter((v) => v.startsWith("http"))
+      .filter(isBlueCoreUri)
 
   return {
     bfAdminMetadataRefs: getObjectUris(`${BF}adminMetadata`),

--- a/src/reducers/resourceHelpers.js
+++ b/src/reducers/resourceHelpers.js
@@ -1,4 +1,4 @@
-import { emptyValue } from "utilities/Utilities"
+import { emptyValue, isBlueCoreUri } from "utilities/Utilities"
 import {
   literalRequiredError,
   literalRegexValidationError,
@@ -120,10 +120,14 @@ export const updateResourceLabel = (state, value) => {
 export const updateBibframeRefs = (state, value) => {
   if (!value.uri) return state
   const newSubject = { ...state.subjects[value.rootSubjectKey] }
+  // The BIBFRAME ref buckets below are shown in the relationships display, which
+  // can only fetch and render Blue Core resources. External refs (e.g.
+  // bf:hasItem pointing at id.loc.gov) are omitted.
+  const isBlueCore = isBlueCoreUri(value.uri)
   switch (value.propertyUri) {
     case "http://id.loc.gov/ontologies/bibframe/adminMetadata":
       // References admin metadata
-      addToKeyArray(newSubject, "bfAdminMetadataRefs", value.uri)
+      if (isBlueCore) addToKeyArray(newSubject, "bfAdminMetadataRefs", value.uri)
       break
     case "http://sinopia.io/vocabulary/localAdminMetadataFor":
       // References Sinopia localadmin metadata
@@ -131,19 +135,19 @@ export const updateBibframeRefs = (state, value) => {
       break
     case "http://id.loc.gov/ontologies/bibframe/itemOf":
       // References instance
-      addToKeyArray(newSubject, "bfInstanceRefs", value.uri)
+      if (isBlueCore) addToKeyArray(newSubject, "bfInstanceRefs", value.uri)
       break
     case "http://id.loc.gov/ontologies/bibframe/hasItem":
       // References item
-      addToKeyArray(newSubject, "bfItemRefs", value.uri)
+      if (isBlueCore) addToKeyArray(newSubject, "bfItemRefs", value.uri)
       break
     case "http://id.loc.gov/ontologies/bibframe/instanceOf":
       // References work
-      addToKeyArray(newSubject, "bfWorkRefs", value.uri)
+      if (isBlueCore) addToKeyArray(newSubject, "bfWorkRefs", value.uri)
       break
     case "http://id.loc.gov/ontologies/bibframe/hasInstance":
       // References instance
-      addToKeyArray(newSubject, "bfInstanceRefs", value.uri)
+      if (isBlueCore) addToKeyArray(newSubject, "bfInstanceRefs", value.uri)
       break
     default:
     // Nothing

--- a/src/utilities/Utilities.js
+++ b/src/utilities/Utilities.js
@@ -8,6 +8,7 @@ import { JsonLdParser } from "jsonld-streaming-parser"
 import { Writer as N3Writer } from "n3"
 import dateFormat from "date-and-time"
 import SerializerJsonld from "@rdfjs/serializer-jsonld-ext"
+import Config from "Config"
 
 const concatStream = require("concat-stream")
 const Readable = require("stream").Readable
@@ -38,6 +39,23 @@ export const isValidURI = (value) => {
 
 export const isHttp = (uri) =>
   _.startsWith(uri, "http://") || _.startsWith(uri, "https://")
+
+/**
+ * Determines whether a URI identifies a Blue Core resource, i.e. one that can
+ * be fetched as application/vnd.sinopia+json. Blue Core resources share an
+ * origin with the Blue Core API; external URIs (e.g. id.loc.gov) do not.
+ * Note: the API base includes a path (.../api) while resources are siblings
+ * (.../instances, .../works, ...), so we compare origin rather than prefix.
+ * @param {string} uri to test
+ * @return {boolean} true if the URI is a Blue Core resource URI
+ */
+export const isBlueCoreUri = (uri) => {
+  try {
+    return new URL(uri).origin === new URL(Config.sinopiaApiBase).origin
+  } catch (e) {
+    return false
+  }
+}
 
 /**
  * Loads N3 into a dataset.


### PR DESCRIPTION
Closes #141

## Problem

The "Relationships" view fetches every related ref (`bf:hasItem`, `bf:instanceOf`, `bf:hasInstance`, `bf:itemOf`, `bf:adminMetadata`) via `fetchResource`, which requests `application/vnd.sinopia+json`. That works for Blue Core resources (Works/Instances), but `bf:hasItem` points at external `id.loc.gov` item URIs that aren't stored in bluecore-api. id.loc.gov ignores the accept header and returns HTML, so parsing fails and users see:

> Error getting relationship http://id.loc.gov/resources/items/14300125: Error parsing resource: NetworkError when attempting to fetch resource.

## Change

For now, only display relationships to Blue Core resources; external refs are filtered out. If Sinopia later stores Item resources in bluecore-api (or gains the ability to view/edit resources elsewhere on the web), this can be relaxed.

- Add `isBlueCoreUri(uri)` in `utilities/Utilities.js`. It compares URL **origin** against `Config.sinopiaApiBase` — not a string prefix, since the API base carries an `/api` path while resources are siblings at `/instances`, `/works`, etc.
- Filter refs at both collection points:
  - `refsFromDataset` (search-results path)
  - `updateBibframeRefs` (editor left-nav path)

External refs are dropped upstream, so they never trigger a fetch, render a row, or expose View/Edit/Copy controls. A resource whose only refs are external now correctly shows no "Relationships" control.

## Tests

- `isBlueCoreUri` unit tests (Blue Core, external, and non-URI values)
- search path omits an external `bf:hasItem` ref
- reducer omits an external item ref
- existing relationship feature/selector/reducer tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)