### PR TITLE
Stop template defaults from overriding real loaded data

### DIFF
--- a/__tests__/__template_fixtures__/testing_merge_defaults_host.json
+++ b/__tests__/__template_fixtures__/testing_merge_defaults_host.json
@@ -1,0 +1,112 @@
+[
+  {
+    "@id": "_:b8",
+    "@type": [
+      "http://sinopia.io/vocabulary/PropertyTemplate"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Nested resource",
+        "@language": "en"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyUri": [
+      {
+        "@id": "http://sinopia.io/testing/MergeDefaultsHost/property1"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyType": [
+      {
+        "@id": "http://sinopia.io/vocabulary/propertyType/resource"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasResourceAttributes": [
+      {
+        "@id": "_:b9"
+      }
+    ]
+  },
+  {
+    "@id": "_:b9",
+    "@type": [
+      "http://sinopia.io/vocabulary/ResourcePropertyTemplate"
+    ],
+    "http://sinopia.io/vocabulary/hasResourceTemplateId": [
+      {
+        "@id": "resourceTemplate:testing:mergeDefaultsMatch"
+      },
+      {
+        "@id": "resourceTemplate:testing:mergeDefaultsSibling"
+      }
+    ]
+  },
+  {
+    "@id": "http://localhost:3000/resource/resourceTemplate:testing:mergeDefaultsHost",
+    "http://sinopia.io/vocabulary/hasResourceTemplate": [
+      {
+        "@value": "sinopia:template:resource"
+      }
+    ],
+    "@type": [
+      "http://sinopia.io/vocabulary/ResourceTemplate"
+    ],
+    "http://sinopia.io/vocabulary/hasResourceId": [
+      {
+        "@value": "resourceTemplate:testing:mergeDefaultsHost",
+        "@language": "en"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasClass": [
+      {
+        "@id": "http://sinopia.io/testing/MergeDefaultsHost"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Merge Defaults Host",
+        "@language": "en"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasRemark": [
+      {
+        "@value": "A template with a nested resource property that has multiple valueSubjectTemplateKeys, used to test that unmatched sibling templates do not have their defaults applied when loading from a dataset.",
+        "@language": "en"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyTemplate": [
+      {
+        "@list": [
+          {
+            "@id": "_:b8"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "@id": "http://sinopia.io/testing/MergeDefaultsHost",
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Merge Defaults Host",
+        "@language": "en"
+      }
+    ]
+  },
+  {
+    "@id": "http://sinopia.io/testing/MergeDefaultsHost/property1",
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Property1",
+        "@language": "en"
+      }
+    ]
+  },
+  {
+    "@id": "http://sinopia.io/vocabulary/propertyType/resource",
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "nested resource"
+      }
+    ]
+  }
+]

--- a/__tests__/__template_fixtures__/testing_merge_defaults_match.json
+++ b/__tests__/__template_fixtures__/testing_merge_defaults_match.json
@@ -1,0 +1,93 @@
+[
+  {
+    "@id": "_:b8",
+    "@type": [
+      "http://sinopia.io/vocabulary/PropertyTemplate"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Literal input",
+        "@language": "en"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyUri": [
+      {
+        "@id": "http://sinopia.io/testing/MergeDefaultsMatch/property1"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyType": [
+      {
+        "@id": "http://sinopia.io/vocabulary/propertyType/literal"
+      }
+    ]
+  },
+  {
+    "@id": "http://localhost:3000/resource/resourceTemplate:testing:mergeDefaultsMatch",
+    "http://sinopia.io/vocabulary/hasResourceTemplate": [
+      {
+        "@value": "sinopia:template:resource"
+      }
+    ],
+    "@type": [
+      "http://sinopia.io/vocabulary/ResourceTemplate"
+    ],
+    "http://sinopia.io/vocabulary/hasResourceId": [
+      {
+        "@value": "resourceTemplate:testing:mergeDefaultsMatch",
+        "@language": "en"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasClass": [
+      {
+        "@id": "http://sinopia.io/testing/MergeDefaultsMatch"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Merge Defaults Match",
+        "@language": "en"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasRemark": [
+      {
+        "@value": "A template that contains a single literal input and no default. This is the valueSubjectTemplateKeys entry that real dataset values match.",
+        "@language": "en"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyTemplate": [
+      {
+        "@list": [
+          {
+            "@id": "_:b8"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "@id": "http://sinopia.io/testing/MergeDefaultsMatch",
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Merge Defaults Match",
+        "@language": "en"
+      }
+    ]
+  },
+  {
+    "@id": "http://sinopia.io/testing/MergeDefaultsMatch/property1",
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Property1",
+        "@language": "en"
+      }
+    ]
+  },
+  {
+    "@id": "http://sinopia.io/vocabulary/propertyType/literal",
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "literal"
+      }
+    ]
+  }
+]

--- a/__tests__/__template_fixtures__/testing_merge_defaults_sibling.json
+++ b/__tests__/__template_fixtures__/testing_merge_defaults_sibling.json
@@ -1,0 +1,109 @@
+[
+  {
+    "@id": "_:b8",
+    "@type": [
+      "http://sinopia.io/vocabulary/PropertyTemplate"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Literal input with default",
+        "@language": "en"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyUri": [
+      {
+        "@id": "http://sinopia.io/testing/MergeDefaultsSibling/property1"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyType": [
+      {
+        "@id": "http://sinopia.io/vocabulary/propertyType/literal"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasLiteralAttributes": [
+      {
+        "@id": "_:b9"
+      }
+    ]
+  },
+  {
+    "@id": "_:b9",
+    "@type": [
+      "http://sinopia.io/vocabulary/LiteralPropertyTemplate"
+    ],
+    "http://sinopia.io/vocabulary/hasDefault": [
+      {
+        "@value": "Sibling default value"
+      }
+    ]
+  },
+  {
+    "@id": "http://localhost:3000/resource/resourceTemplate:testing:mergeDefaultsSibling",
+    "http://sinopia.io/vocabulary/hasResourceTemplate": [
+      {
+        "@value": "sinopia:template:resource"
+      }
+    ],
+    "@type": [
+      "http://sinopia.io/vocabulary/ResourceTemplate"
+    ],
+    "http://sinopia.io/vocabulary/hasResourceId": [
+      {
+        "@value": "resourceTemplate:testing:mergeDefaultsSibling",
+        "@language": "en"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasClass": [
+      {
+        "@id": "http://sinopia.io/testing/MergeDefaultsSibling"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Merge Defaults Sibling",
+        "@language": "en"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasRemark": [
+      {
+        "@value": "A template that contains a single literal input with a configured default. This is a valueSubjectTemplateKeys entry that real dataset values never match, used to confirm its default is not applied on load.",
+        "@language": "en"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyTemplate": [
+      {
+        "@list": [
+          {
+            "@id": "_:b8"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "@id": "http://sinopia.io/testing/MergeDefaultsSibling",
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Merge Defaults Sibling",
+        "@language": "en"
+      }
+    ]
+  },
+  {
+    "@id": "http://sinopia.io/testing/MergeDefaultsSibling/property1",
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Property1",
+        "@language": "en"
+      }
+    ]
+  },
+  {
+    "@id": "http://sinopia.io/vocabulary/propertyType/literal",
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "literal"
+      }
+    ]
+  }
+]

--- a/__tests__/__template_fixtures__/testing_required_single_default_host.json
+++ b/__tests__/__template_fixtures__/testing_required_single_default_host.json
@@ -1,0 +1,122 @@
+[
+  {
+    "@id": "_:b8",
+    "@type": [
+      "http://sinopia.io/vocabulary/PropertyTemplate"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Required nested resource",
+        "@language": "en"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyUri": [
+      {
+        "@id": "http://sinopia.io/testing/RequiredSingleDefaultHost/property1"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyType": [
+      {
+        "@id": "http://sinopia.io/vocabulary/propertyType/resource"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyAttribute": [
+      {
+        "@id": "http://sinopia.io/vocabulary/propertyAttribute/required"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasResourceAttributes": [
+      {
+        "@id": "_:b9"
+      }
+    ]
+  },
+  {
+    "@id": "_:b9",
+    "@type": [
+      "http://sinopia.io/vocabulary/ResourcePropertyTemplate"
+    ],
+    "http://sinopia.io/vocabulary/hasResourceTemplateId": [
+      {
+        "@id": "resourceTemplate:testing:mergeDefaultsSibling"
+      }
+    ]
+  },
+  {
+    "@id": "http://localhost:3000/resource/resourceTemplate:testing:requiredSingleDefaultHost",
+    "http://sinopia.io/vocabulary/hasResourceTemplate": [
+      {
+        "@value": "sinopia:template:resource"
+      }
+    ],
+    "@type": [
+      "http://sinopia.io/vocabulary/ResourceTemplate"
+    ],
+    "http://sinopia.io/vocabulary/hasResourceId": [
+      {
+        "@value": "resourceTemplate:testing:requiredSingleDefaultHost",
+        "@language": "en"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasClass": [
+      {
+        "@id": "http://sinopia.io/testing/RequiredSingleDefaultHost"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Required Single Default Host",
+        "@language": "en"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasRemark": [
+      {
+        "@value": "A template with a REQUIRED nested resource property that has a single valueSubjectTemplateKeys entry whose own property has a configured default -- used to test what happens when the source dataset has no data for this property at all.",
+        "@language": "en"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyTemplate": [
+      {
+        "@list": [
+          {
+            "@id": "_:b8"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "@id": "http://sinopia.io/testing/RequiredSingleDefaultHost",
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "RequiredSingleDefaultHost",
+        "@language": "en"
+      }
+    ]
+  },
+  {
+    "@id": "http://sinopia.io/testing/RequiredSingleDefaultHost/property1",
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Property1",
+        "@language": "en"
+      }
+    ]
+  },
+  {
+    "@id": "http://sinopia.io/vocabulary/propertyType/resource",
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "nested resource"
+      }
+    ]
+  },
+  {
+    "@id": "http://sinopia.io/vocabulary/propertyAttribute/required",
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "required"
+      }
+    ]
+  }
+]

--- a/__tests__/__template_fixtures__/testing_suppressed_uri2.json
+++ b/__tests__/__template_fixtures__/testing_suppressed_uri2.json
@@ -1,0 +1,106 @@
+[
+  {
+    "@id": "_:b11",
+    "@type": [
+      "http://sinopia.io/vocabulary/PropertyTemplate"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "URI input",
+        "@language": "en"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyUri": [
+      {
+        "@id": "http://sinopia.io/testing/Uri2/property1"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyType": [
+      {
+        "@id": "http://sinopia.io/vocabulary/propertyType/uri"
+      }
+    ]
+  },
+  {
+    "@id": "http://localhost:3000/resource/resourceTemplate:testing:suppressedUri2",
+    "http://sinopia.io/vocabulary/hasResourceTemplate": [
+      {
+        "@value": "sinopia:template:resource"
+      }
+    ],
+    "@type": [
+      "http://sinopia.io/vocabulary/ResourceTemplate"
+    ],
+    "http://sinopia.io/vocabulary/hasResourceId": [
+      {
+        "@value": "resourceTemplate:testing:suppressedUri2",
+        "@language": "en"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasClass": [
+      {
+        "@id": "http://sinopia.io/testing/Uri2"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "URI2",
+        "@language": "en"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasRemark": [
+      {
+        "@value": "A second suppressible template with the same shape as testing:suppressedUri, used to test that two suppressible candidates are not disambiguated by guessing.",
+        "@language": "en"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasResourceAttribute": [
+      {
+        "@id": "http://sinopia.io/vocabulary/resourceAttribute/suppressible"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyTemplate": [
+      {
+        "@list": [
+          {
+            "@id": "_:b11"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "@id": "http://sinopia.io/testing/Uri2",
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "URI2",
+        "@language": "en"
+      }
+    ]
+  },
+  {
+    "@id": "http://sinopia.io/testing/Uri2/property1",
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Property1",
+        "@language": "en"
+      }
+    ]
+  },
+  {
+    "@id": "http://sinopia.io/vocabulary/propertyType/uri",
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "uri"
+      }
+    ]
+  },
+  {
+    "@id": "http://sinopia.io/vocabulary/resourceAttribute/suppressible",
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "suppressible"
+      }
+    ]
+  }
+]

--- a/__tests__/__template_fixtures__/testing_suppressible_ambiguous.json
+++ b/__tests__/__template_fixtures__/testing_suppressible_ambiguous.json
@@ -1,0 +1,130 @@
+[
+  {
+    "@id": "http://localhost:3000/resource/resourceTemplate:testing:suppressibleAmbiguous",
+    "http://sinopia.io/vocabulary/hasResourceTemplate": [
+      {
+        "@value": "sinopia:template:resource"
+      }
+    ],
+    "@type": [
+      "http://sinopia.io/vocabulary/ResourceTemplate"
+    ],
+    "http://sinopia.io/vocabulary/hasResourceId": [
+      {
+        "@value": "resourceTemplate:testing:suppressibleAmbiguous",
+        "@language": "en"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasClass": [
+      {
+        "@id": "http://sinopia.io/testing/SuppressibleAmbiguous"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Suppressible ambiguous nested resource",
+        "@language": "en"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasRemark": [
+      {
+        "@value": "A template with a nested resource property that has two suppressible valueSubjectTemplateKeys, used to test that an untyped URI value is not disambiguated by guessing.",
+        "@language": "en"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyTemplate": [
+      {
+        "@list": [
+          {
+            "@id": "_:b5"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "@id": "_:b5",
+    "@type": [
+      "http://sinopia.io/vocabulary/PropertyTemplate"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Suppressible ambiguous nested resource",
+        "@language": "en"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyUri": [
+      {
+        "@id": "http://sinopia.io/testing/SuppressibleAmbiguous/property1"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasPropertyType": [
+      {
+        "@id": "http://sinopia.io/vocabulary/propertyType/resource"
+      }
+    ],
+    "http://sinopia.io/vocabulary/hasResourceAttributes": [
+      {
+        "@id": "_:b6"
+      }
+    ]
+  },
+  {
+    "@id": "_:b6",
+    "@type": [
+      "http://sinopia.io/vocabulary/ResourcePropertyTemplate"
+    ],
+    "http://sinopia.io/vocabulary/hasResourceTemplateId": [
+      {
+        "@id": "resourceTemplate:testing:suppressedUri"
+      },
+      {
+        "@id": "resourceTemplate:testing:suppressedUri2"
+      }
+    ]
+  },
+  {
+    "@id": "http://sinopia.io/testing/SuppressibleAmbiguous/property1",
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Property1",
+        "@language": "en"
+      }
+    ]
+  },
+  {
+    "@id": "http://sinopia.io/testing/SuppressibleAmbiguous",
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "SuppressibleAmbiguous",
+        "@language": "en"
+      }
+    ]
+  },
+  {
+    "@id": "http://sinopia.io/vocabulary/propertyType/resource",
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "nested resource"
+      }
+    ]
+  },
+  {
+    "@id": "resourceTemplate:testing:suppressedUri",
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "URI",
+        "@language": "en"
+      }
+    ]
+  },
+  {
+    "@id": "resourceTemplate:testing:suppressedUri2",
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "URI2",
+        "@language": "en"
+      }
+    ]
+  }
+]

--- a/__tests__/actionCreators/resources.newResourceFromDataset.test.js
+++ b/__tests__/actionCreators/resources.newResourceFromDataset.test.js
@@ -411,4 +411,214 @@ _:c14n0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://sinopia.io/tes
       })
     })
   })
+
+  describe("loading a resource with a nested resource property that has multiple valueSubjectTemplateKeys", () => {
+    // Only one of the two valueSubjectTemplateKeys (mergeDefaultsMatch) has real
+    // data in the dataset. The other (mergeDefaultsSibling) has a configured
+    // default. Loading should not populate that sibling's default value: doing
+    // so would let template defaults masquerade as (and, on save, silently
+    // overwrite) data that was never in the source RDF.
+    const mergeDefaultsUri =
+      "http://localhost:3000/resource/c7db5404-7d7d-40ac-b38e-c821d2c3ae3d"
+    const mergeDefaultsN3 = `<${mergeDefaultsUri}> <http://sinopia.io/vocabulary/hasResourceTemplate> "resourceTemplate:testing:mergeDefaultsHost" .
+    <${mergeDefaultsUri}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://sinopia.io/testing/MergeDefaultsHost> .
+    <${mergeDefaultsUri}> <http://sinopia.io/testing/MergeDefaultsHost/property1> _:b1 .
+    _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://sinopia.io/testing/MergeDefaultsMatch> .
+    _:b1 <http://sinopia.io/testing/MergeDefaultsMatch/property1> "Real value"@en .
+    `
+
+    const store = mockStore(createState())
+
+    it("does not apply the unmatched sibling template's default value", async () => {
+      const dataset = await datasetFromN3(mergeDefaultsN3)
+      const result = await store.dispatch(
+        newResourceFromDataset(
+          dataset,
+          mergeDefaultsUri,
+          null,
+          "testerrorkey"
+        )
+      )
+      expect(result).toBe(true)
+
+      const actions = store.getActions()
+      const addSubjectAction = actions.find(
+        (action) => action.type === "ADD_SUBJECT"
+      )
+      expect(addSubjectAction).not.toBeNull()
+
+      const resource = addSubjectAction.payload
+      const property = resource.properties[0]
+
+      const matchValue = property.values.find(
+        (value) =>
+          value.valueSubject.subjectTemplate.id ===
+          "resourceTemplate:testing:mergeDefaultsMatch"
+      )
+      expect(matchValue.valueSubject.properties[0].values[0].literal).toBe(
+        "Real value"
+      )
+
+      const siblingValue = property.values.find(
+        (value) =>
+          value.valueSubject.subjectTemplate.id ===
+          "resourceTemplate:testing:mergeDefaultsSibling"
+      )
+      expect(siblingValue).not.toBeUndefined()
+      // Should be null/empty, not populated from the sibling's configured default.
+      expect(siblingValue.valueSubject.properties[0].values).toBeFalsy()
+
+      // And on save, the unmatched sibling (having no real content) should not
+      // be written to the graph at all -- confirming no phantom default value
+      // is persisted.
+      const actualRdf = new GraphBuilder(resource).graph.toCanonical()
+      expect(actualRdf).not.toMatch("Sibling default value")
+      expect(actualRdf).toMatch("Real value")
+    })
+  })
+
+  describe("loading a suppressed nested resource with no local rdf:type", () => {
+    // Unlike "loading a suppressed nested resource" above, <http://foo/bar>
+    // has no local rdf:type triple -- the normal shape for a reference to an
+    // external, shared vocabulary term. There is exactly one candidate
+    // template (resourceTemplate:testing:suppressedUri) and it is marked
+    // suppressible, so the value should still be recovered.
+    const n3 = `<> <http://sinopia.io/vocabulary/hasResourceTemplate> "resourceTemplate:testing:suppressible" .
+    <> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://sinopia.io/testing/Suppressible> .
+    <> <http://sinopia.io/testing/Suppressible/property1> <http://foo/bar> .
+    <http://foo/bar> <http://www.w3.org/2000/01/rdf-schema#label> "Foo Bar"@en .
+    `
+
+    const store = mockStore(createState())
+
+    it("recovers the value using the sole suppressible candidate", async () => {
+      const dataset = await datasetFromN3(n3.replace(/<>/g, `<${uri}>`))
+      const result = await store.dispatch(
+        newResourceFromDataset(dataset, uri, null, "testerrorkey")
+      )
+      expect(result).toBe(true)
+
+      const actions = store.getActions()
+      const addSubjectAction = actions.find(
+        (action) => action.type === "ADD_SUBJECT"
+      )
+      expect(addSubjectAction).not.toBeNull()
+
+      const property = addSubjectAction.payload.properties[0]
+      const recoveredValue =
+        property.values[0].valueSubject.properties[0].values[0]
+      expect(recoveredValue.uri).toBe("http://foo/bar")
+      expect(recoveredValue.label).toBe("Foo Bar")
+
+      // On save, the recovered value round-trips as a flat, suppressed URI --
+      // the real reference is written out, not silently dropped or replaced.
+      const actualRdf = new GraphBuilder(
+        addSubjectAction.payload
+      ).graph.toCanonical()
+      expect(actualRdf).toMatch(
+        "<http://sinopia.io/testing/Suppressible/property1> <http://foo/bar>"
+      )
+      expect(actualRdf).toMatch(
+        '<http://foo/bar> <http://www.w3.org/2000/01/rdf-schema#label> "Foo Bar"@en'
+      )
+      // Since no local rdf:type triple was found for the recovered value,
+      // the recovered subject has no known classes, so (unlike a value
+      // matched by a real local type) no rdf:type is re-stamped on save.
+      // The core reference is preserved either way -- this only documents
+      // the known asymmetry with a genuinely Sinopia-authored round-trip.
+      expect(actualRdf).not.toMatch(
+        '<http://foo/bar> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>'
+      )
+    })
+  })
+
+  describe("loading a resource property with two suppressible candidates and no local rdf:type", () => {
+    // resourceTemplate:testing:suppressedUri and :suppressedUri2 are both
+    // suppressible and have the identical shape (a bare uri + label). With no
+    // local rdf:type on the value to disambiguate them, the loader must not
+    // guess -- the real value should not appear under either candidate.
+    const ambiguousUri =
+      "http://localhost:3000/resource/c7db5404-7d7d-40ac-b38e-c821d2c3ae3c"
+    const n3 = `<${ambiguousUri}> <http://sinopia.io/vocabulary/hasResourceTemplate> "resourceTemplate:testing:suppressibleAmbiguous" .
+    <${ambiguousUri}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://sinopia.io/testing/SuppressibleAmbiguous> .
+    <${ambiguousUri}> <http://sinopia.io/testing/SuppressibleAmbiguous/property1> <http://foo/bar> .
+    <http://foo/bar> <http://www.w3.org/2000/01/rdf-schema#label> "Foo Bar"@en .
+    `
+
+    const store = mockStore(createState())
+
+    it("does not guess which candidate the value represents", async () => {
+      const dataset = await datasetFromN3(n3)
+      const result = await store.dispatch(
+        newResourceFromDataset(dataset, ambiguousUri, null, "testerrorkey")
+      )
+      expect(result).toBe(true)
+
+      const actions = store.getActions()
+      const addSubjectAction = actions.find(
+        (action) => action.type === "ADD_SUBJECT"
+      )
+      expect(addSubjectAction).not.toBeNull()
+
+      const property = addSubjectAction.payload.properties[0]
+      expect(property.values).toHaveLength(2)
+
+      const uris = property.values.map(
+        (value) => value.valueSubject.properties[0].values?.[0]?.uri
+      )
+      expect(uris).not.toContain("http://foo/bar")
+
+      // Both candidate placeholders are empty, so on save neither is written
+      // -- the real reference is lost from the editor, but nothing wrong (or
+      // guessed) is persisted either.
+      const actualRdf = new GraphBuilder(
+        addSubjectAction.payload
+      ).graph.toCanonical()
+      expect(actualRdf).not.toMatch("http://foo/bar")
+    })
+  })
+
+  describe("loading a resource with a required nested resource property that has no data at all", () => {
+    // resourceTemplate:testing:mergeDefaultsSibling has a configured literal
+    // default (see the merge-defaults describe block above), but here it's
+    // the SOLE valueSubjectTemplateKeys entry for a REQUIRED property, and
+    // the dataset has no triple at all for that property -- unlike the
+    // merge-defaults case, this never reaches newValuesFromDatasetByPropertyUri's
+    // "resource" branch (there's no object to try matching), so it goes
+    // through newProperty's required-property pre-population
+    // (valuesForExpandedProperty) instead. That path threads noDefaults
+    // through just like the dataset-merge path, so the default should not
+    // appear here either.
+    const requiredUri =
+      "http://localhost:3000/resource/c7db5404-7d7d-40ac-b38e-c821d2c3ae3b"
+    const n3 = `<${requiredUri}> <http://sinopia.io/vocabulary/hasResourceTemplate> "resourceTemplate:testing:requiredSingleDefaultHost" .
+    <${requiredUri}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://sinopia.io/testing/RequiredSingleDefaultHost> .
+    `
+
+    const store = mockStore(createState())
+
+    it("does not apply the candidate template's default value", async () => {
+      const dataset = await datasetFromN3(n3)
+      const result = await store.dispatch(
+        newResourceFromDataset(dataset, requiredUri, null, "testerrorkey")
+      )
+      expect(result).toBe(true)
+
+      const actions = store.getActions()
+      const addSubjectAction = actions.find(
+        (action) => action.type === "ADD_SUBJECT"
+      )
+      expect(addSubjectAction).not.toBeNull()
+
+      const resource = addSubjectAction.payload
+      const property = resource.properties[0]
+      expect(property.values).toHaveLength(1)
+
+      const innerProperty = property.values[0].valueSubject.properties[0]
+      expect(innerProperty.values).toBeFalsy()
+
+      const actualRdf = new GraphBuilder(resource).graph.toCanonical()
+      expect(actualRdf).not.toMatch("Sibling default value")
+    })
+  })
 })

--- a/__tests__/testUtilities/fixtureLoaderHelper.js
+++ b/__tests__/testUtilities/fixtureLoaderHelper.js
@@ -45,9 +45,12 @@ const templateFilenames = {
   "resourceTemplate:testing:literal": "testing_literal.json",
   "resourceTemplate:testing:uri": "testing_uri.json",
   "resourceTemplate:testing:suppressedUri": "testing_suppressed_uri.json",
+  "resourceTemplate:testing:suppressedUri2": "testing_suppressed_uri2.json",
   "resourceTemplate:testing:inputs": "testing_inputs.json",
   "resourceTemplate:testing:ordered": "testing_ordered.json",
   "resourceTemplate:testing:suppressible": "testing_suppressible.json",
+  "resourceTemplate:testing:suppressibleAmbiguous":
+    "testing_suppressible_ambiguous.json",
   "resourceTemplate:testing:multiplePropertyUris":
     "testing_multiple_property_uris.json",
   "resourceTemplate:testing:suppressLanguage": "testing_suppress_language.json",
@@ -59,6 +62,13 @@ const templateFilenames = {
   "resourceTemplate:testing:multipleClassInputs":
     "testing_multiple_class_inputs.json",
   "resourceTemplate:testing:lookup": "testing_lookups.json",
+  "resourceTemplate:testing:mergeDefaultsHost": "testing_merge_defaults_host.json",
+  "resourceTemplate:testing:mergeDefaultsMatch":
+    "testing_merge_defaults_match.json",
+  "resourceTemplate:testing:mergeDefaultsSibling":
+    "testing_merge_defaults_sibling.json",
+  "resourceTemplate:testing:requiredSingleDefaultHost":
+    "testing_required_single_default_host.json",
 }
 
 export const hasFixtureResource = (uri) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sinopia_editor",
-  "version": "3.17.138",
+  "version": "3.17.139",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "sinopia_editor",
-      "version": "3.17.138",
+      "version": "3.17.139",
       "license": "Apache-2.0",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^1.2.36",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sinopia_editor",
-  "version": "3.17.137",
+  "version": "3.17.138",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "sinopia_editor",
-      "version": "3.17.137",
+      "version": "3.17.138",
       "license": "Apache-2.0",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^1.2.36",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "editor",
     "rdf"
   ],
-  "version": "3.17.137",
+  "version": "3.17.138",
   "homepage": "http://github.com/LD4P/sinopia_editor/",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "editor",
     "rdf"
   ],
-  "version": "3.17.138",
+  "version": "3.17.139",
   "homepage": "http://github.com/LD4P/sinopia_editor/",
   "repository": {
     "type": "git",

--- a/src/actionCreators/resourceHelpers.js
+++ b/src/actionCreators/resourceHelpers.js
@@ -330,7 +330,13 @@ const templatePromisesFor = (property, errorKey, dispatch) =>
   property.propertyTemplate.valueSubjectTemplateKeys.map((resourceTemplateId) =>
     dispatch(newSubject(null, resourceTemplateId, {}, errorKey)).then(
       (subject) =>
-        dispatch(newPropertiesFromTemplates(subject, false, errorKey)).then(
+        // noDefaults is true: these subjects are placeholders for every
+        // valueSubjectTemplateKeys entry, used by mergeValues to find the one
+        // matching the dataset. Populating them with template defaults would let
+        // those defaults leak into merged values as extra siblings, or entirely
+        // replace real data whenever the dataset value isn't recognized (e.g., an
+        // external authority URI with no local rdf:type triple to match against).
+        dispatch(newPropertiesFromTemplates(subject, true, errorKey)).then(
           (properties) => {
             subject.properties = properties
             return newValueSubject(
@@ -459,23 +465,41 @@ const newNestedResourceFromObject =
       if (compactChildRtIds.length > 1) {
         throw `More than one resource template matches: ${compactChildRtIds}`
       }
-      // No matching resource template, so do nothing
-      if (_.isEmpty(compactChildRtIds)) {
+
+      if (!_.isEmpty(compactChildRtIds)) {
+        context.usedDataset.addAll(typeQuads)
+
+        // One resource template
+        const suppress = obj.termType === "NamedNode"
+        return dispatch(
+          recursiveResourceFromDataset(
+            obj,
+            null,
+            compactChildRtIds[0],
+            suppress,
+            context
+          )
+        ).then((subject) => newValueSubject(property, propertyUri, subject))
+      }
+
+      // No local rdf:type triple matched a candidate template -- e.g. the
+      // object is a bare reference to an external, shared vocabulary term or
+      // resource, which has no reason to restate its own type locally. If the
+      // object is a plain URI and exactly one candidate template is marked
+      // suppressible (i.e., designed to round-trip as a flat URI with no
+      // local type assertion), use that template directly rather than
+      // discarding real data.
+      if (obj.termType !== "NamedNode") {
         return null
       }
-      context.usedDataset.addAll(typeQuads)
-
-      // One resource template
-      const suppress = obj.termType === "NamedNode"
       return dispatch(
-        recursiveResourceFromDataset(
-          obj,
-          null,
-          compactChildRtIds[0],
-          suppress,
-          context
-        )
-      ).then((subject) => newValueSubject(property, propertyUri, subject))
+        selectSuppressibleResourceTemplateId(property.propertyTemplate, context)
+      ).then((suppressibleRtId) => {
+        if (!suppressibleRtId) return null
+        return dispatch(
+          recursiveResourceFromDataset(obj, null, suppressibleRtId, true, context)
+        ).then((subject) => newValueSubject(property, propertyUri, subject))
+      })
     })
   }
 
@@ -500,6 +524,30 @@ const selectResourceTemplateId =
         })
       )
     )
+
+// Used only when no candidate template's class matched a local rdf:type
+// triple on the object. Safe to use only when exactly one candidate is
+// suppressible -- with more than one, there's no way to know which the value
+// represents, so the caller should decline (return undefined) rather than guess.
+const selectSuppressibleResourceTemplateId =
+  (propertyTemplate, { resourceTemplatePromises, errorKey }) =>
+  (dispatch) =>
+    Promise.all(
+      propertyTemplate.valueSubjectTemplateKeys.map((resourceTemplateId) =>
+        dispatch(
+          loadResourceTemplate(
+            resourceTemplateId,
+            resourceTemplatePromises,
+            errorKey
+          )
+        ).then((subjectTemplate) =>
+          subjectTemplate?.suppressible ? resourceTemplateId : undefined
+        )
+      )
+    ).then((resourceTemplateIds) => {
+      const compactIds = _.compact(resourceTemplateIds)
+      return compactIds.length === 1 ? compactIds[0] : undefined
+    })
 
 const newLiteralFromObject = (obj, property, propertyUri) =>
   newLiteralValue(property, propertyUri, obj.value, obj.language)


### PR DESCRIPTION
## Why was this change made?
Fixes #53 
When loading a resource whose nested resource property offers multiple candidate templates, an unmatched sibling was built with defaults applied, letting configured default values leak into merged results as if they were real data (e.g. Work's "Related Work" property fabricating an "Uncontrolled Series" entry that was never in the source record).

Separately, when a nested resource value has no local `rdf:type` triple to match against a candidate template — the normal shape for a reference to an external, shared vocabulary term — the loader discarded the real value entirely and fell back to the sole candidate's default, silently replacing real data (e.g. an Instance's real Media/Carrier Type downgrading to "unmediated"/"volume"). Now the real value is recovered when exactly one candidate is marked suppressible; when more than one candidate qualifies there's no way to disambiguate, so nothing is guessed and the value is left unmatched (a known, accepted limitation).

## How was this change tested?
new file:   __tests__/__template_fixtures__/testing_merge_defaults_host.json
new file:   __tests__/__template_fixtures__/testing_merge_defaults_match.json
new file:   __tests__/__template_fixtures__/testing_merge_defaults_sibling.json
new file:   __tests__/__template_fixtures__/testing_required_single_default_host.json
new file:   __tests__/__template_fixtures__/testing_suppressed_uri2.json
new file:   __tests__/__template_fixtures__/testing_suppressible_ambiguous.json

<h1>Cases where default values are overriding the values of incoming data</h1>
<h2>1. An unmatched sibling in a multi-choice property gets populated with its own default value.</h2>
When a resource property offers a choice between multiple templates (e.g., Work's "Related Work" property lets you pick either a Relation or an "Uncontrolled Series"), loading a record that matches only one of those choices should leave the other, unmatched choice empty. Instead, the unmatched sibling was being built with `noDefaults=false`, so if its template had a configured default value
<h3>Currently:</h3>

<img width="735" height="878" alt="Image" src="https://github.com/user-attachments/assets/adb52dba-3512-42ce-ba3e-021b715426a8" />

<h3>After Fix:</h3>

<img width="702" height="797" alt="Image" src="https://github.com/user-attachments/assets/2f9592a9-3c18-4c1b-9af6-aa92ac1adac6" />

<h2>2. A real value gets silently replaced by the template default, with no trace it happened.</h2>
For a single-candidate resource property (e.g., Instance's Media Type or Carrier Type), the loader tries to match the incoming value's `rdf:type` against the one candidate template to confirm it applies. But a value like `bf:media → <mediaTypes/c>` is just a bare reference to an external, shared vocabulary term — it has no local rdf:type triple (normal, valid data shape). Finding no type match, the loader concluded "no match" and discarded the real value entirely, leaving only the candidate template's own configured default (mediaTypes/n/"unmediated") to populate the field 

<h3>Currently:</h3>
Shows the wrong defaults (mediaTypes/n/"unmediated", carriers/nc/"volume") 
<img width="709" height="755" alt="Image" src="https://github.com/user-attachments/assets/f66ff79e-afa6-4583-833c-470f685b4de4" />

<h3>After Fix:</h3>

<img width="703" height="789" alt="Image" src="https://github.com/user-attachments/assets/f97e46af-4d0c-4ed0-b8b8-3e8897877259" />
## Which documentation and/or configurations were updated?
N/A


