### PR TITLE
Fix nested resource loading

### DIFF
--- a/__tests__/TemplatesBuilder.test.js
+++ b/__tests__/TemplatesBuilder.test.js
@@ -277,6 +277,30 @@ _:b4_c14n1 <http://www.w3.org/2000/01/rdf-schema#label> "Uber template1, propert
     )
   })
 
+  it("preserves full HTTPS URLs in nested resource property template", async () => {
+    const rdf = `<> <http://sinopia.io/vocabulary/hasClass> <http://id.loc.gov/ontologies/bibframe/Uber1> .
+<> <http://sinopia.io/vocabulary/hasPropertyTemplate> _:b1_c14n1 .
+<> <http://sinopia.io/vocabulary/hasResourceId> <resourceTemplate:testing:uber1> .
+<> <http://sinopia.io/vocabulary/hasResourceTemplate> "sinopia:template:resource" .
+<> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://sinopia.io/vocabulary/ResourceTemplate> .
+<> <http://www.w3.org/2000/01/rdf-schema#label> "Uber template1"@en .
+<http://sinopia.io/vocabulary/propertyType/resource> <http://www.w3.org/2000/01/rdf-schema#label> "nested resource" .
+_:b1_c14n1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b4_c14n1 .
+_:b1_c14n1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b4_c14n0 <http://sinopia.io/vocabulary/hasResourceTemplateId> <https://dev.bcld.info/profiles/5f862f31-6f1a-469c-ba66-f3cea0bc6599> .
+_:b4_c14n0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://sinopia.io/vocabulary/ResourcePropertyTemplate> .
+_:b4_c14n1 <http://sinopia.io/vocabulary/hasPropertyType> <http://sinopia.io/vocabulary/propertyType/resource> .
+_:b4_c14n1 <http://sinopia.io/vocabulary/hasResourceAttributes> _:b4_c14n0 .
+_:b4_c14n1 <http://sinopia.io/vocabulary/hasPropertyUri> <http://id.loc.gov/ontologies/bibframe/uber/template1/property1> .
+_:b4_c14n1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://sinopia.io/vocabulary/PropertyTemplate> .
+_:b4_c14n1 <http://www.w3.org/2000/01/rdf-schema#label> "Uber template1, property2"@en .`
+    const dataset = await datasetFromN3(rdf)
+    const subjectTemplate = new TemplatesBuilder(dataset, "").build()
+    expect(
+      subjectTemplate.propertyTemplates[0].valueSubjectTemplateKeys
+    ).toEqual(["https://dev.bcld.info/profiles/5f862f31-6f1a-469c-ba66-f3cea0bc6599"])
+  })
+
   it("builds lookup property template", async () => {
     const rdf = `<> <http://sinopia.io/vocabulary/hasClass> <http://id.loc.gov/ontologies/bibframe/Uber1> .
 <> <http://sinopia.io/vocabulary/hasPropertyTemplate> _:b1_c14n1 .

--- a/src/TemplatesBuilder.js
+++ b/src/TemplatesBuilder.js
@@ -295,7 +295,7 @@ export default class TemplatesBuilder {
       propertyTemplate.valueSubjectTemplateKeys = this.valuesFor(
         attributeTerm,
         "http://sinopia.io/vocabulary/hasResourceTemplateId"
-      ).map((subjectTemplateKey) => resourceToName(subjectTemplateKey))
+      )
       propertyTemplate.key = `${
         propertyTemplate.key
       } > ${propertyTemplate.valueSubjectTemplateKeys.sort().join(", ")}`


### PR DESCRIPTION
## Why was this change made?

Fixes #131 

The cause of this bug was that resourceToName() was stripping full URI down to the bare UUID, then treated as a non-URI, triggering the search+fallback path which constructed the wrong …/api/resource/… URL. With this fix, full URLs pass straight through to loadResourceTemplateWithoutValidation which correctly detects isFullUri = true and fetches them directly.

https://github.com/user-attachments/assets/09d2daf4-d5c0-4c06-8d27-e82167360f24



## How was this change tested?



## Which documentation and/or configurations were updated?



