### PR TITLE
Fix crash when detecting language by passing in keycloak

### DIFF
--- a/__tests__/feature/editing/detectingLanguage.test.js
+++ b/__tests__/feature/editing/detectingLanguage.test.js
@@ -1,0 +1,74 @@
+import { renderApp, createHistory } from "testUtils"
+import { fireEvent, screen } from "@testing-library/react"
+import { featureSetup, resourceHeaderSelector } from "featureUtils"
+import Config from "Config"
+
+// A realistic, non-empty keycloak object, unlike the top-level mock used by
+// editingLanguage.test.js. This lets the real getJwt(keycloak) code path in
+// sinopiaApi.detectLanguage run, which editingLanguage.test.js mocks away
+// entirely and so cannot catch a regression there.
+jest.mock("KeycloakContext", () => ({
+  useKeycloak: jest.fn().mockReturnValue({
+    keycloak: { token: "Secret-Token" },
+  }),
+}))
+
+featureSetup()
+
+describe("clicking the language link", () => {
+  it("opens the language modal with a populated language list, without crashing", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue({
+        data: [{ language: "en", score: 0.99 }],
+      }),
+    })
+
+    const history = createHistory(["/editor/resourceTemplate:testing:literal"])
+    renderApp(null, history)
+
+    await screen.findByText("Literal", {
+      selector: resourceHeaderSelector,
+    })
+
+    // The resource template has now loaded via fixtures. Switch fixtures off
+    // so detectLanguage takes its real getJwt/fetch path below instead of its
+    // fixture shortcut, which never touches keycloak at all.
+    jest
+      .spyOn(Config, "useResourceTemplateFixtures", "get")
+      .mockReturnValue(false)
+
+    // Add a value
+    const input = screen.getByPlaceholderText("Literal input")
+    fireEvent.change(input, { target: { value: "foo" } })
+    fireEvent.keyDown(input, { key: "Enter", code: 13, charCode: 13 })
+
+    // Click the language link, which triggers detectLanguage(text, keycloak)
+    // for real. If keycloak isn't passed through from InputLang.jsx, getJwt
+    // throws and the modal never appears.
+    const langBtn = screen.getByTestId("Change language for foo")
+    fireEvent.click(langBtn)
+
+    screen.getByRole("heading", { name: "Select language tag for foo" })
+
+    // The resource's default language ("en") is preselected, so clear it
+    // first to see the full, unfiltered language list.
+    fireEvent.click(screen.getByTestId("Clear language for foo"))
+
+    const langInput = screen.getByTestId("langComponent-foo")
+    fireEvent.click(langInput)
+
+    await screen.findByText("English (en)")
+    screen.getByText("Tai (taw)")
+
+    // Confirms the real detectLanguage/getJwt path ran end-to-end.
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining("/helpers/langDetection"),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer Secret-Token",
+        }),
+      })
+    )
+  }, 15000)
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sinopia_editor",
-  "version": "3.17.137",
+  "version": "3.17.138",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "sinopia_editor",
-      "version": "3.17.137",
+      "version": "3.17.138",
       "license": "Apache-2.0",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^1.2.36",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "editor",
     "rdf"
   ],
-  "version": "3.17.137",
+  "version": "3.17.138",
   "homepage": "http://github.com/LD4P/sinopia_editor/",
   "repository": {
     "type": "git",

--- a/src/components/editor/inputs/InputLang.jsx
+++ b/src/components/editor/inputs/InputLang.jsx
@@ -17,10 +17,12 @@ import {
 import { selectNormValue } from "selectors/resources"
 import { parseLangTag, stringifyLangTag } from "utilities/Language"
 import { detectLanguage } from "sinopiaApi"
+import { useKeycloak } from "KeycloakContext"
 import _ from "lodash"
 
 const InputLang = () => {
   const dispatch = useDispatch()
+  const { keycloak } = useKeycloak()
   const valueKey = useSelector((state) => selectCurrentLangModalValue(state))
   const value = useSelector((state) => selectNormValue(state, valueKey))
   const langOptions = useSelector((state) => selectLanguages(state))
@@ -77,7 +79,7 @@ const InputLang = () => {
   useEffect(() => {
     if (_.isEmpty(textValue)) return
 
-    detectLanguage(textValue)
+    detectLanguage(textValue, keycloak)
       .then((resp) => {
         if (!_.isEmpty(resp) && resp[0].score >= 0.75) {
           // Strip optional region subtag
@@ -91,7 +93,7 @@ const InputLang = () => {
         // Not surfacing error to user.
         console.error("Error detecting language", err)
       })
-  }, [textValue])
+  }, [textValue, keycloak])
 
   const findOptions = (id, options) => {
     if (!id) return []


### PR DESCRIPTION
## Why was this change made?
Fixes #123 

- Fixed `InputLang.jsx` calling detectLanguage(textValue) without the required keycloak argument, so getJwt(keycloak) crashed on undefined.token. Added useKeycloak() and passed keycloak through.

## How was this change tested?
- Added `tests/feature/editing/detectingLanguage.test.js`
- Unlike the existing editingLanguage.test.js, which mocks sinopiaApi.detectLanguage away entirely (so it can never exercise getJwt), this test uses the real detectLanguage with a realistic non-empty keycloak object and a mocked fetch. It clicks the language link, confirms the "Select language tag" modal appears with a populated language list, and asserts fetch was actually called with the Authorization header built from keycloak.token — proving the real code path runs end-to-end.



## Which documentation and/or configurations were updated?
N/A


