### PR TITLE
Fix API path for marc conversion

### DIFF
--- a/__tests__/components/load/LoadByRDFForm.test.js
+++ b/__tests__/components/load/LoadByRDFForm.test.js
@@ -99,7 +99,7 @@ describe("LoadByRDFForm", () => {
       })
 
       // First call: marc2xml
-      expect(fetchMock.mock.calls[0][0]).toBe("http://localhost:3000/api/marc2xml")
+      expect(fetchMock.mock.calls[0][0]).toBe("http://localhost:3000/marc2xml")
       expect(fetchMock.mock.calls[0][1]).toMatchObject({
         method: "POST",
         headers: expect.objectContaining({
@@ -109,7 +109,7 @@ describe("LoadByRDFForm", () => {
       })
 
       // Second call: marc2bibframe
-      expect(fetchMock.mock.calls[1][0]).toBe("http://localhost:3000/api/marc2bibframe")
+      expect(fetchMock.mock.calls[1][0]).toBe("http://localhost:3000/marc2bibframe")
       expect(fetchMock.mock.calls[1][1]).toMatchObject({
         method: "POST",
         headers: expect.objectContaining({
@@ -236,7 +236,7 @@ describe("LoadByRDFForm", () => {
 
       await waitFor(() => {
         expect(global.fetch).toHaveBeenCalledWith(
-          "http://localhost:3000/api/works",
+          "http://localhost:3000/works",
           expect.objectContaining({
             method: "POST",
             headers: expect.objectContaining({
@@ -283,7 +283,7 @@ describe("LoadByRDFForm", () => {
 
       // /api/works should not be called
       expect(global.fetch).not.toHaveBeenCalledWith(
-        "http://localhost:3000/api/works",
+        "http://localhost:3000/works",
         expect.anything()
       )
     })

--- a/src/components/load/LoadByRDFForm.jsx
+++ b/src/components/load/LoadByRDFForm.jsx
@@ -68,7 +68,7 @@ const LoadByRDFForm = () => {
 
     const reader = new FileReader()
     reader.onload = (e) => {
-      fetch(`${Config.sinopiaApiBase}/api/marc2xml`, {
+      fetch(`${Config.sinopiaApiBase}/marc2xml`, {
         method: "POST",
         headers: {
           "Content-Type": "application/marc",
@@ -83,7 +83,7 @@ const LoadByRDFForm = () => {
         })
         .then((marcXml) => {
           setMarcText(prettyXml(marcXml))
-          return fetch(`${Config.sinopiaApiBase}/api/marc2bibframe`, {
+          return fetch(`${Config.sinopiaApiBase}/marc2bibframe`, {
             method: "POST",
             headers: {
               "Content-Type": "application/xml",
@@ -141,7 +141,7 @@ const LoadByRDFForm = () => {
     dispatch(clearErrors(errorKey))
 
     if (isMarcBibframe) {
-      fetch(`${Config.sinopiaApiBase}/api/works`, {
+      fetch(`${Config.sinopiaApiBase}/works`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",


### PR DESCRIPTION
## Why was this change made?

Realized the path is slightly wrong as adding `api` in code breaks the path when the env path is set properly.

## How was this change tested?



## Which documentation and/or configurations were updated?



